### PR TITLE
Change config paths to ~/.dippy/config.toml and dippy.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Dippy auto-detects your AI assistant, but you can force a mode:
 
 ## Configuration
 
-Create `~/.config/dippy/dippy.toml` for global settings, or `.dippy.toml` in your project root for project-specific rules.
+Create `~/.dippy/config.toml` for global settings, or `dippy.toml` (or `.dippy.toml`) in your project root for project-specific rules.
 
 ```toml
 version = 1
@@ -150,7 +150,7 @@ aliases = { k = "kubectl", tf = "terraform", g = "git" }
 
 **Precedence:** `confirm` → `approve` → built-in handlers → `SIMPLE_SAFE`
 
-**Script paths:** Relative paths are resolved against the project root (where `.dippy.toml` lives). Only the exact file matches—a script with the same name in a different directory won't be approved.
+**Script paths:** Relative paths are resolved against the project root (where the config file lives). Only the exact file matches—a script with the same name in a different directory won't be approved.
 
 ---
 

--- a/src/dippy/core/config.py
+++ b/src/dippy/core/config.py
@@ -2,8 +2,8 @@
 Configuration system for Dippy.
 
 Loads config from:
-- ~/.config/dippy/dippy.toml (global defaults)
-- .dippy.toml (project override, merged)
+- ~/.dippy/config.toml (global defaults)
+- dippy.toml or .dippy.toml in project root (first found wins, merged with global)
 
 Example config:
     # What you want auto-approved
@@ -69,7 +69,7 @@ def load_config(cwd: Optional[str] = None) -> Config:
     config = Config()
 
     # Load global config
-    global_path = Path.home() / ".config" / "dippy" / "dippy.toml"
+    global_path = Path.home() / ".dippy" / "config.toml"
     if global_path.exists():
         global_config = _load_config_file(global_path)
         config = config.merge(global_config)
@@ -111,12 +111,14 @@ def _load_config_file(path: Path) -> Config:
 
 
 def _find_project_config(cwd: Path) -> Optional[Path]:
-    """Walk up from cwd to find .dippy.toml."""
+    """Walk up from cwd to find dippy.toml or .dippy.toml (first found wins)."""
     current = cwd.resolve()
     while current != current.parent:
-        config_path = current / ".dippy.toml"
-        if config_path.exists():
-            return config_path
+        # dippy.toml takes priority over .dippy.toml
+        for name in ("dippy.toml", ".dippy.toml"):
+            config_path = current / name
+            if config_path.exists():
+                return config_path
         current = current.parent
     return None
 


### PR DESCRIPTION
## Summary
- Change global config path from `~/.config/dippy/dippy.toml` to `~/.dippy/config.toml`
- Support both `dippy.toml` and `.dippy.toml` for project config (visible takes priority)
- Add tests for project config file discovery

## Test plan
- [x] Unit tests added for `_find_project_config`
- [ ] Manual test: verify `~/.dippy/config.toml` is loaded
- [ ] Manual test: verify `dippy.toml` takes priority over `.dippy.toml`