### PR TITLE
Add justfile for task automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Dippy
+
+Shell command approval hook for AI coding assistants.
+
+## Commands
+
+```bash
+just test        # Run tests (Python 3.14)
+just test-all    # All Python versions (3.11-3.14) — required before committing
+just fmt         # Format and lint (ruff)
+```

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ aliases = { k = "kubectl", tf = "terraform", g = "git" }
 
 ---
 
+## Development
+
+```bash
+just test        # Run tests (Python 3.14)
+just test-py312  # Run tests on specific version
+just test-all    # Run tests on all versions (3.11-3.14)
+just fmt         # Format and lint (ruff)
+```
+
+---
+
 ## Contributing
 
 PRs welcome! See [prompts/adding-commands.md](prompts/adding-commands.md) for instructions on adding support for new CLI tools.
@@ -192,6 +203,6 @@ Workflow:
 1. User pastes "Hook PreToolUse:Bash requires confirmation" output
 2. Add pattern to appropriate handler in `src/dippy/cli/`
 3. Add test case to `tests/cli/test_*.py`
-4. Run `uv run pytest`
+4. Run `just test` (must pass `just test-all` before committing)
 
 </details>

--- a/bin/test-all-versions
+++ b/bin/test-all-versions
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-for v in 3.11 3.12 3.13 3.14; do
-  echo "=== Python $v ==="
-  uv run --python $v pytest -q
-done
-echo "All versions passed!"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,23 @@
+set shell := ["bash", "-cu"]
+
+_test-py version:
+    uv run --python {{version}} pytest
+
+# Run tests on Python 3.11
+test-py311: (_test-py "3.11")
+# Run tests on Python 3.12
+test-py312: (_test-py "3.12")
+# Run tests on Python 3.13
+test-py313: (_test-py "3.13")
+# Run tests on Python 3.14
+test-py314: (_test-py "3.14")
+
+# Run tests (default: 3.14)
+alias test := test-py314
+
+# Run tests on all supported Python versions
+test-all: test-py311 test-py312 test-py313 test-py314
+
+# Format and lint
+fmt:
+    uv run ruff check --fix && uv run ruff format

--- a/prompts/adding-commands.md
+++ b/prompts/adding-commands.md
@@ -68,7 +68,7 @@ Categories to cover:
 ### 3. Run Tests to See Failures
 
 ```bash
-uv run pytest tests/cli/test_<command>.py -v
+just test
 ```
 
 ### 4. Create the Handler
@@ -115,16 +115,22 @@ KNOWN_HANDLERS = {
 ### 6. Run Tests Until All Pass
 
 ```bash
-uv run pytest tests/cli/test_<command>.py -v
+just test
 ```
 
-### 7. Run Linter
+### 7. Run All Python Versions Before Committing
+
+```bash
+just test-all
+```
+
+### 8. Run Linter
 
 ```bash
 uv run ruff check src/ tests/
 ```
 
-### 8. Create a Pull Request
+### 9. Create a Pull Request
 
 ```bash
 git add -A
@@ -142,7 +148,7 @@ EOF
 )"
 ```
 
-### 9. Merge the PR
+### 10. Merge the PR
 
 ```bash
 gh pr merge --squash --delete-branch

--- a/prompts/check-comprehensive.md
+++ b/prompts/check-comprehensive.md
@@ -81,7 +81,7 @@ Group tests logically with comments. Include:
 
 Run the tests:
 ```bash
-uv run pytest tests/cli/test_<tool>.py -v
+just test
 ```
 
 For each failure:
@@ -93,9 +93,9 @@ Repeat until all tests pass.
 
 ### 6. Verify Full Suite
 
-Run the full test suite to ensure no regressions:
+Run all Python versions before committing:
 ```bash
-uv run pytest tests/ -q
+just test-all
 ```
 
 ## Output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
-    "parable>=0.1.0",
+    "parable @ git+https://github.com/ldayton/Parable.git",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Add `justfile` with commands for testing across Python 3.11-3.14 and formatting
- Add `CLAUDE.md` with quick reference for common commands
- Update README and prompt docs to use `just` commands
- Switch parable dependency to git source

## Test plan

- [ ] Run `just test` to verify tests pass
- [ ] Run `just test-all` for multi-version testing
- [ ] Run `just fmt` to verify formatting works