### PR TITLE
Fix allow-redirect rules not approving commands

### DIFF
--- a/src/dippy/dippy.py
+++ b/src/dippy/dippy.py
@@ -367,6 +367,7 @@ def check_command(command: str, config: Config, cwd: Path) -> dict:
         except ValueError:
             log_decision("ask", "invalid bash", command=command)
             return ask("invalid bash")
+        all_allowed = True
         for target in targets:
             redirect_match = match_redirect(target, config, cwd)
             if redirect_match:
@@ -392,9 +393,12 @@ def check_command(command: str, config: Config, cwd: Path) -> dict:
                         command=command,
                     )
                     return ask(f"redirect to {target}: {msg}")
-        # No config match for any redirect - default ask
-        log_decision("ask", "output redirect", command=command)
-        return ask("output redirect")
+            else:
+                all_allowed = False  # No rule matched this target
+        if not all_allowed:
+            log_decision("ask", "output redirect", command=command)
+            return ask("output redirect")
+        # All redirects explicitly allowed by config - continue to check command
 
     # Check command substitutions - inner commands must be safe
     cmdsub_result = _check_command_substitutions(command, config, cwd)

--- a/tests/core/test_router.py
+++ b/tests/core/test_router.py
@@ -59,6 +59,14 @@ class TestOutputRedirects:
         result = check("cat foo.txt > bar.txt")
         assert needs_confirmation(result)
 
+    def test_redirect_allowed_by_config(self, check, tmp_path):
+        """Redirect to path allowed by config should be approved."""
+        from dippy.core.config import Config, Rule
+
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/**")])
+        result = check("echo test > /tmp/foo.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
 
 class TestPipelines:
     """Tests for pipeline command handling."""


### PR DESCRIPTION
## Summary

- Fix bug where `allow-redirect` rules matched but commands still prompted for confirmation
- When all redirect targets matched allow rules, the loop would `continue` through all targets, then fall through to `return ask("output redirect")` instead of continuing to check the command

## Reproduction

```
# .dippy
allow-redirect /tmp/**
```

```bash
echo test > /tmp/foo.txt  # Would prompt "output redirect" even though rule matched
```