### PR TITLE
Add fd command support

### DIFF
--- a/src/dippy/cli/fd.py
+++ b/src/dippy/cli/fd.py
@@ -1,0 +1,50 @@
+"""Fd command handler for Dippy.
+
+Fd is a file search tool. All searches are safe, but --exec and --exec-batch
+delegate to inner commands for safety checks.
+"""
+
+import shlex
+
+from dippy.cli import Classification
+
+COMMANDS = ["fd"]
+
+# Execution flags that take commands as arguments
+EXEC_FLAGS = frozenset({"-x", "--exec", "-X", "--exec-batch"})
+
+
+def classify(tokens: list[str]) -> Classification:
+    """Classify fd command by checking for execution flags."""
+    if len(tokens) < 2:
+        return Classification("approve", description="fd")
+
+    # Check if any execution flag is present
+    exec_flag_idx = None
+    for i, token in enumerate(tokens[1:], start=1):
+        if token in EXEC_FLAGS:
+            exec_flag_idx = i
+            break
+
+    # No execution flag - just a search, safe to approve
+    if exec_flag_idx is None:
+        return Classification("approve", description="fd search")
+
+    # Extract inner command after the execution flag
+    inner_start = exec_flag_idx + 1
+    if inner_start >= len(tokens):
+        return Classification("ask", description="fd --exec (no command)")
+
+    inner_tokens = tokens[inner_start:]
+    if not inner_tokens:
+        return Classification("ask", description="fd --exec (no command)")
+
+    # Delegate to inner command check
+    inner_cmd = " ".join(
+        shlex.quote(t) if " " in t or not t else t for t in inner_tokens
+    )
+    return Classification(
+        "delegate",
+        inner_command=inner_cmd,
+        description=f"fd --exec {inner_tokens[0]}",
+    )

--- a/src/dippy/core/patterns.py
+++ b/src/dippy/core/patterns.py
@@ -43,13 +43,12 @@ SIMPLE_SAFE = frozenset(
         "readlink",
         "realpath",
         # Search/filter (read-only)
-        # Note: find has its own handler due to -exec/-delete flags
+        # Note: find and fd have their own handlers due to -exec flags
         "grep",
         "rg",
         "ripgrep",
         "ag",
         "ack",
-        "fd",
         "locate",
         # Text processing (read-only)
         # Note: sed and sort have their own handlers due to -i/-o flags

--- a/tests/cli/test_fd.py
+++ b/tests/cli/test_fd.py
@@ -1,0 +1,77 @@
+"""Test cases for fd."""
+
+import pytest
+from conftest import is_approved, needs_confirmation
+
+TESTS = [
+    # Safe operations - basic searches
+    ("fd", True),
+    ("fd pattern", True),
+    ("fd pattern path/to/dir", True),
+    ("fd -e txt", True),
+    ("fd --extension py", True),
+    # Safe operations - with various flags
+    ("fd -H pattern", True),
+    ("fd --hidden pattern", True),
+    ("fd -I pattern", True),
+    ("fd --no-ignore pattern", True),
+    ("fd -u pattern", True),
+    ("fd --unrestricted pattern", True),
+    ("fd -t f pattern", True),
+    ("fd --type file pattern", True),
+    ("fd -t d pattern", True),
+    ("fd --type directory pattern", True),
+    ("fd -d 3 pattern", True),
+    ("fd --max-depth 3 pattern", True),
+    ("fd -E node_modules pattern", True),
+    ("fd --exclude '*.pyc' pattern", True),
+    ("fd -a pattern", True),
+    ("fd --absolute-path pattern", True),
+    ("fd -l pattern", True),
+    ("fd --list-details pattern", True),
+    ("fd -L pattern", True),
+    ("fd --follow pattern", True),
+    ("fd -p pattern", True),
+    ("fd --full-path pattern", True),
+    ("fd -g pattern", True),
+    ("fd --glob pattern", True),
+    ("fd -s pattern", True),
+    ("fd --case-sensitive pattern", True),
+    ("fd -i pattern", True),
+    ("fd --ignore-case pattern", True),
+    ("fd -S +1m pattern", True),
+    ("fd --size +1m pattern", True),
+    ("fd --changed-within 1week pattern", True),
+    ("fd --changed-before 2024-01-01 pattern", True),
+    ("fd -0 pattern", True),
+    ("fd --print0 pattern", True),
+    ("fd -q pattern", True),
+    ("fd --quiet pattern", True),
+    ("fd --help", True),
+    ("fd -h", True),
+    ("fd --version", True),
+    ("fd -V", True),
+    # Unsafe operations - execute commands with unsafe inner commands
+    ("fd -x rm", False),
+    ("fd --exec rm", False),
+    ("fd -X rm", False),
+    ("fd --exec-batch rm", False),
+    ("fd pattern -X vim", False),
+    ("fd pattern --exec-batch vim", False),
+    ("fd -e py -x python", False),
+    # Safe operations - execute with safe inner commands
+    ("fd -x echo", True),
+    ("fd --exec echo", True),
+    ("fd pattern -x cat", True),
+    ("fd pattern --exec cat", True),
+    ("fd --type f --exec cat {}", True),
+]
+
+
+@pytest.mark.parametrize("command,expected", TESTS)
+def test_fd(check, command: str, expected: bool):
+    result = check(command)
+    if expected:
+        assert is_approved(result), f"Expected approve: {command}"
+    else:
+        assert needs_confirmation(result), f"Expected confirm: {command}"


### PR DESCRIPTION
## Summary

Add support for the `fd` command (modern file search tool).

- Safe search operations are auto-approved
- `--exec` and `--exec-batch` flags delegate to inner command checks
- Removed `fd` from `SIMPLE_SAFE` to enable handler logic

## Changes

- `src/dippy/cli/fd.py`: New handler for fd command
- `src/dippy/core/patterns.py`: Removed fd from SIMPLE_SAFE
- `tests/cli/test_fd.py`: 57 test cases covering search and exec scenarios

## Examples

```bash
fd pattern              # ✅ approved (safe search)
fd -x cat              # ✅ approved (delegates to safe cat)
fd -x rm               # ❓ asks (delegates to unsafe rm)
fd --exec-batch vim    # ❓ asks (vim requires confirmation)
```

## Testing

All 9215 tests pass across Python 3.11-3.14.