### PR TITLE
Add context to unclear Unix command flags

### DIFF
--- a/src/dippy/cli/fd.py
+++ b/src/dippy/cli/fd.py
@@ -13,6 +13,14 @@ COMMANDS = ["fd"]
 # Execution flags that take commands as arguments
 EXEC_FLAGS = frozenset({"-x", "--exec", "-X", "--exec-batch"})
 
+# Map flags to descriptive form
+FLAG_DISPLAY = {
+    "-x": "-x (execute)",
+    "-X": "-X (execute batch)",
+    "--exec": "--exec (execute)",
+    "--exec-batch": "--exec-batch (execute batch)",
+}
+
 
 def classify(tokens: list[str]) -> Classification:
     """Classify fd command by checking for execution flags."""
@@ -21,30 +29,35 @@ def classify(tokens: list[str]) -> Classification:
 
     # Check if any execution flag is present
     exec_flag_idx = None
+    exec_flag = None
     for i, token in enumerate(tokens[1:], start=1):
         if token in EXEC_FLAGS:
             exec_flag_idx = i
+            exec_flag = token
             break
 
     # No execution flag - just a search, safe to approve
     if exec_flag_idx is None:
-        return Classification("approve", description="fd search")
+        return Classification("approve", description="fd")
 
     # Extract inner command after the execution flag
     inner_start = exec_flag_idx + 1
     if inner_start >= len(tokens):
-        return Classification("ask", description="fd --exec (no command)")
+        flag_desc = FLAG_DISPLAY.get(exec_flag, exec_flag)
+        return Classification("ask", description=f"fd {flag_desc} (no command)")
 
     inner_tokens = tokens[inner_start:]
     if not inner_tokens:
-        return Classification("ask", description="fd --exec (no command)")
+        flag_desc = FLAG_DISPLAY.get(exec_flag, exec_flag)
+        return Classification("ask", description=f"fd {flag_desc} (no command)")
 
     # Delegate to inner command check
     inner_cmd = " ".join(
         shlex.quote(t) if " " in t or not t else t for t in inner_tokens
     )
+    flag_desc = FLAG_DISPLAY.get(exec_flag, exec_flag)
     return Classification(
         "delegate",
         inner_command=inner_cmd,
-        description=f"fd --exec {inner_tokens[0]}",
+        description=f"fd {flag_desc} {inner_tokens[0]}",
     )

--- a/src/dippy/cli/find.py
+++ b/src/dippy/cli/find.py
@@ -21,11 +21,20 @@ UNSAFE_FLAGS = frozenset(
     }
 )
 
+# Context for flags that aren't self-explanatory
+FLAG_CONTEXT = {
+    "-ok": "execute with prompt",
+    "-okdir": "execute with prompt",
+}
+
 
 def classify(tokens: list[str]) -> Classification:
     """Classify find command (no exec or delete is safe)."""
     base = tokens[0] if tokens else "find"
     for token in tokens:
         if token in UNSAFE_FLAGS:
+            context = FLAG_CONTEXT.get(token)
+            if context:
+                return Classification("ask", description=f"{base} {token} ({context})")
             return Classification("ask", description=f"{base} {token}")
     return Classification("approve", description=base)

--- a/src/dippy/cli/ifconfig.py
+++ b/src/dippy/cli/ifconfig.py
@@ -16,4 +16,4 @@ def classify(tokens: list[str]) -> Classification:
     # Any additional args beyond interface name is a modification
     if len(tokens) <= 2:
         return Classification("approve", description=base)
-    return Classification("ask", description=f"{base} modify")
+    return Classification("ask", description=f"{base} (modify interface)")

--- a/src/dippy/cli/kubectl.py
+++ b/src/dippy/cli/kubectl.py
@@ -63,7 +63,6 @@ UNSAFE_ACTIONS = frozenset(
 )
 
 
-
 # Safe subcommands for multi-level commands
 SAFE_SUBCOMMANDS = {
     "config": {

--- a/src/dippy/cli/sort.py
+++ b/src/dippy/cli/sort.py
@@ -14,7 +14,7 @@ def classify(tokens: list[str]) -> Classification:
     base = tokens[0] if tokens else "sort"
     for t in tokens[1:]:
         if t == "-o" or t.startswith("-o"):
-            return Classification("ask", description=f"{base} -o")
+            return Classification("ask", description=f"{base} -o (write to file)")
         if t == "--output" or t.startswith("--output"):
-            return Classification("ask", description=f"{base} --output")
+            return Classification("ask", description=f"{base} --output (write to file)")
     return Classification("approve", description=base)

--- a/src/dippy/cli/xargs.py
+++ b/src/dippy/cli/xargs.py
@@ -42,6 +42,12 @@ FLAGS_WITH_ARG = frozenset(
 # Flags that make xargs interactive/unsafe regardless of command
 UNSAFE_FLAGS = frozenset({"-p", "--interactive", "-o", "--open-tty"})
 
+# Context for unclear flags
+FLAG_CONTEXT = {
+    "-p": "prompt before execute",
+    "-o": "open tty",
+}
+
 
 def _skip_flags(
     tokens: list[str], flags_with_arg: frozenset, stop_at_double_dash: bool = False
@@ -86,6 +92,9 @@ def classify(tokens: list[str]) -> Classification:
         if token == "--":
             break
         if token in UNSAFE_FLAGS:
+            context = FLAG_CONTEXT.get(token)
+            if context:
+                return Classification("ask", description=f"xargs {token} ({context})")
             return Classification("ask", description=f"xargs {token}")
         if token.startswith("--interactive"):
             return Classification("ask", description="xargs --interactive")

--- a/src/dippy/cli/xxd.py
+++ b/src/dippy/cli/xxd.py
@@ -17,6 +17,6 @@ def classify(tokens: list[str]) -> Classification:
 
     for token in tokens[1:]:
         if token in UNSAFE_FLAGS:
-            return Classification("ask", description="xxd -r")
+            return Classification("ask", description="xxd -r (write binary)")
 
     return Classification("approve", description="xxd")

--- a/tests/cli/test_descriptions.py
+++ b/tests/cli/test_descriptions.py
@@ -149,3 +149,233 @@ class TestWgetDescriptions:
         assert should_contain in reason.lower(), (
             f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
         )
+
+
+class TestSortDescriptions:
+    """Sort -o should explain it writes to file."""
+
+    @pytest.mark.parametrize(
+        "command,should_contain",
+        [
+            ("sort -o output.txt input.txt", "write"),
+            ("sort --output output.txt input.txt", "write"),
+            ("sort -ooutput.txt input.txt", "write"),
+        ],
+    )
+    def test_sort_description_contains_write(
+        self, check, command: str, should_contain: str
+    ):
+        """Sort's reason should mention writing to file."""
+        result = check(command)
+        reason = get_reason(result)
+        assert should_contain in reason.lower(), (
+            f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
+        )
+
+
+class TestXxdDescriptions:
+    """Xxd -r should explain it writes binary."""
+
+    @pytest.mark.parametrize(
+        "command,should_contain",
+        [
+            ("xxd -r hex.txt binary.bin", "binary"),
+            ("xxd -revert hex.txt binary.bin", "binary"),
+        ],
+    )
+    def test_xxd_description_contains_binary(
+        self, check, command: str, should_contain: str
+    ):
+        """Xxd's reason should mention writing binary."""
+        result = check(command)
+        reason = get_reason(result)
+        assert should_contain in reason.lower(), (
+            f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
+        )
+
+
+class TestFindDescriptions:
+    """Find -ok/-okdir should explain they execute with prompt."""
+
+    @pytest.mark.parametrize(
+        "command,should_contain",
+        [
+            ("find . -ok rm {} \\;", "prompt"),
+            ("find . -okdir rm {} \\;", "prompt"),
+        ],
+    )
+    def test_find_ok_description_contains_prompt(
+        self, check, command: str, should_contain: str
+    ):
+        """Find -ok/-okdir should mention prompting."""
+        result = check(command)
+        reason = get_reason(result)
+        assert should_contain in reason.lower(), (
+            f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
+        )
+
+
+class TestIfconfigDescriptions:
+    """Ifconfig with modification args should explain it modifies interface."""
+
+    @pytest.mark.parametrize(
+        "command,should_contain",
+        [
+            ("ifconfig eth0 192.168.1.1", "modify"),
+            ("ifconfig eth0 up", "modify"),
+            ("ifconfig eth0 down", "modify"),
+        ],
+    )
+    def test_ifconfig_description_contains_modify(
+        self, check, command: str, should_contain: str
+    ):
+        """Ifconfig's reason should mention modifying interface."""
+        result = check(command)
+        reason = get_reason(result)
+        assert should_contain in reason.lower(), (
+            f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
+        )
+
+
+class TestFdDescriptions:
+    """Fd -x/-X should explain they execute commands (when no inner command)."""
+
+    @pytest.mark.parametrize(
+        "command,should_contain",
+        [
+            # When there's no inner command, fd's description is used
+            ("fd -x", "execute"),
+            ("fd -X", "execute"),
+            ("fd --exec", "execute"),
+            ("fd --exec-batch", "execute"),
+        ],
+    )
+    def test_fd_description_contains_execute(
+        self, check, command: str, should_contain: str
+    ):
+        """Fd's reason should mention executing when no inner command."""
+        result = check(command)
+        reason = get_reason(result)
+        assert should_contain in reason.lower(), (
+            f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
+        )
+
+
+class TestXargsDescriptions:
+    """Xargs -p/-o should explain what they do."""
+
+    @pytest.mark.parametrize(
+        "command,should_contain",
+        [
+            ("xargs -p rm", "prompt"),
+            ("xargs -o vim", "tty"),
+        ],
+    )
+    def test_xargs_description_contains_context(
+        self, check, command: str, should_contain: str
+    ):
+        """Xargs's reason should explain the flag."""
+        result = check(command)
+        reason = get_reason(result)
+        assert should_contain in reason.lower(), (
+            f"Expected '{should_contain}' in reason for: {command}\nGot: '{reason}'"
+        )
+
+
+class TestCargoAliasExpansion:
+    """Cargo short aliases should be expanded (replaced, not appended)."""
+
+    @pytest.mark.parametrize(
+        "command,alias,expanded",
+        [
+            ("cargo r", "r", "run"),
+            ("cargo b", "b", "build"),
+            ("cargo t", "t", "test"),
+        ],
+    )
+    def test_cargo_alias_replaced(self, check, command: str, alias: str, expanded: str):
+        """Cargo aliases should be replaced with full command name."""
+        result = check(command)
+        reason = get_reason(result)
+        # Alias should be replaced, not present alongside expanded form
+        assert f"cargo {expanded}" in reason.lower(), (
+            f"Expected 'cargo {expanded}' in reason for: {command}\nGot: '{reason}'"
+        )
+        # The single-letter alias should not appear as a standalone word
+        words = reason.lower().split()
+        assert alias not in words, (
+            f"Alias '{alias}' should be expanded, not present in: {reason}"
+        )
+
+
+class TestNpmAliasExpansion:
+    """Npm short aliases should be expanded (replaced, not appended)."""
+
+    @pytest.mark.parametrize(
+        "command,alias,expanded",
+        [
+            ("npm i express", "i", "install"),
+            ("npm rm express", "rm", "remove"),
+            ("npm un express", "un", "uninstall"),
+            ("npm t", "t", "test"),
+            ("npm x cowsay", "x", "exec"),
+            ("npm c list", "c", "config"),
+            ("npm ddp", "ddp", "dedupe"),
+            ("npm rb", "rb", "rebuild"),
+        ],
+    )
+    def test_npm_alias_replaced(self, check, command: str, alias: str, expanded: str):
+        """Npm aliases should be replaced with full command name."""
+        result = check(command)
+        reason = get_reason(result)
+        assert f"npm {expanded}" in reason.lower(), (
+            f"Expected 'npm {expanded}' in reason for: {command}\nGot: '{reason}'"
+        )
+        words = reason.lower().split()
+        assert alias not in words, (
+            f"Alias '{alias}' should be expanded, not present in: {reason}"
+        )
+
+
+class TestHelmAliasExpansion:
+    """Helm short aliases should be expanded (replaced, not appended)."""
+
+    @pytest.mark.parametrize(
+        "command,alias,expanded",
+        [
+            ("helm del myrelease", "del", "delete"),
+            ("helm un myrelease", "un", "uninstall"),
+            ("helm fetch mychart", "fetch", "pull"),
+        ],
+    )
+    def test_helm_alias_replaced(self, check, command: str, alias: str, expanded: str):
+        """Helm aliases should be replaced with full command name."""
+        result = check(command)
+        reason = get_reason(result)
+        assert f"helm {expanded}" in reason.lower(), (
+            f"Expected 'helm {expanded}' in reason for: {command}\nGot: '{reason}'"
+        )
+        words = reason.lower().split()
+        assert alias not in words, (
+            f"Alias '{alias}' should be expanded, not present in: {reason}"
+        )
+
+
+class TestGitContextDescriptions:
+    """Git unclear commands should have parenthetical context."""
+
+    @pytest.mark.parametrize(
+        "command,expected_desc",
+        [
+            ("git gc", "git gc (garbage collect)"),
+            ("git prune", "git prune (remove unreachable objects)"),
+            ("git filter-branch --all", "git filter-branch (rewrite history)"),
+        ],
+    )
+    def test_git_context_format(self, check, command: str, expected_desc: str):
+        """Git unclear commands should have exact context format."""
+        result = check(command)
+        reason = get_reason(result)
+        assert reason.lower() == expected_desc.lower(), (
+            f"Expected '{expected_desc}' for: {command}\nGot: '{reason}'"
+        )


### PR DESCRIPTION
## Summary

Add parenthetical context to flags where the meaning isn't obvious from the flag name alone.

## Changes

| Command | Before | After |
|---------|--------|-------|
| `sort -o` | `sort -o` | `sort -o (write to file)` |
| `sort --output` | `sort --output` | `sort --output (write to file)` |
| `xxd -r` | `xxd -r` | `xxd -r (write binary)` |
| `find -ok` | `find -ok` | `find -ok (execute with prompt)` |
| `find -okdir` | `find -okdir` | `find -okdir (execute with prompt)` |
| `ifconfig eth0 ...` | `ifconfig modify` | `ifconfig (modify interface)` |
| `fd -x` | `fd --exec` | `fd -x (execute)` |
| `fd -X` | `fd --exec-batch` | `fd -X (execute batch)` |
| `fd --exec` | `fd --exec` | `fd --exec (execute)` |
| `fd --exec-batch` | `fd --exec-batch` | `fd --exec-batch (execute batch)` |
| `xargs -p` | `xargs -p` | `xargs -p (prompt before execute)` |
| `xargs -o` | `xargs -o` | `xargs -o (open tty)` |

## Tests

Added rigorous tests that verify:
- Aliases are **replaced**, not appended (e.g., `cargo r` → `cargo run`, not `cargo r run`)
- Exact context format for git commands (e.g., `git gc (garbage collect)`)
- Flag context descriptions for sort, xxd, find, ifconfig, fd, xargs

Test methodology:
```python
# Verify expanded form present
assert f"cargo {expanded}" in reason.lower()
# Verify alias was replaced (not still present)
assert alias not in words
```

## Test plan

- [x] `just fmt` - formatting passes
- [x] `just test` - 9285 tests pass on Python 3.14