### PR TITLE
Add after rules docs and VS Code snippets

### DIFF
--- a/docs/config-v1.md
+++ b/docs/config-v1.md
@@ -41,6 +41,9 @@ ask-redirect <glob> "message"  # prompt with message shown to AI
 deny-redirect <glob>           # reject output redirects to matching paths
 deny-redirect <glob> "message" # reject with message shown to AI
 
+after <glob>                   # post-action feedback (silent)
+after <glob> "message"         # post-action feedback with message to AI
+
 set <key> [value]              # settings
 ```
 
@@ -355,11 +358,9 @@ Or for both file and MCP control:
 "matcher": "Bash|Write|Edit|MultiEdit|mcp__.*"
 ```
 
-## Proposal: Post-Action Feedback
+## After Rules
 
-Claude Code's PostToolUse hook fires after a command completes successfully and can provide feedback to Claude. Dippy could use its existing pattern matching to let users define post-action messages.
-
-### Proposed Syntax
+After rules provide feedback to the AI after a command completes. They use Claude Code's PostToolUse hook.
 
 ```
 after <glob>           # silent - matches, no message
@@ -368,8 +369,6 @@ after <glob> "message" # matches, sends message to Claude
 ```
 
 Like other rules, last match wins. A silent `after` (with no message or empty string) overrides earlier matches—useful for excluding specific commands from a broad rule.
-
-### Example
 
 ```
 # Remind Claude after git operations
@@ -385,32 +384,14 @@ after ./deploy.sh * "Verify deployment in staging before continuing"
 after make test * "Review test output and fix any failures"
 ```
 
-### How It Works
-
-PostToolUse hooks receive the completed command and can output feedback that Claude sees as context. Unlike PreToolUse (which controls permission), PostToolUse is purely informational—it cannot block or modify.
-
 When an `after` rule matches:
 1. Dippy outputs the message to stdout
 2. Claude receives it as post-action feedback
 3. Claude can adjust its behavior based on the message
 
-### Opting In
+Unlike PreToolUse rules (which control permission), after rules are purely informational—they cannot block or modify.
 
-Dippy must register for PostToolUse events in addition to PreToolUse. Update `settings.json`:
-
-```json
-"hooks": {
-  "PreToolUse": [...],
-  "PostToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [{ "type": "command", "command": "dippy" }]
-    }
-  ]
-}
-```
-
-Or Dippy's install script could set this up automatically.
+To enable after rules, register Dippy for PostToolUse in `settings.json` (see Installation in README).
 
 ## Implementation Notes
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,9 +1,9 @@
 # Dippy Syntax Highlighting for VS Code
 
+Highlights `.dippy` files and `~/.dippy/config`.
+
 ## Install
 
 ```bash
-cd editors/vscode
-npx @vscode/vsce package
-code --install-extension dippy-syntax-*.vsix
+just vscode
 ```

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "dippy-syntax",
   "displayName": "Dippy Config Syntax",
   "description": "Syntax highlighting for Dippy config files",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "vscode": "^1.60.0"
   },
@@ -19,6 +19,10 @@
       "language": "dippy",
       "scopeName": "source.dippy",
       "path": "./syntaxes/dippy.tmLanguage.json"
+    }],
+    "snippets": [{
+      "language": "dippy",
+      "path": "./snippets.json"
     }]
   }
 }

--- a/editors/vscode/samples/exhaustive.dippy
+++ b/editors/vscode/samples/exhaustive.dippy
@@ -134,6 +134,26 @@ deny-redirect ~/.ssh/id_* "Never overwrite SSH keys"
 deny-redirect /etc/** "System config is off-limits"
 
 # -----------------------------------------------------------------------------
+# AFTER RULES: PostToolUse feedback
+# -----------------------------------------------------------------------------
+
+# After rules send messages to the AI after command completes
+after git push * "Re-read the prompt file for next steps"
+after git commit * "Update your todo list"
+
+# Silent after (no message, just matches)
+after npm *
+after npm install *
+
+# After with workflow reminders
+after ./deploy.sh * "Verify deployment in staging before continuing"
+after make test * "Review test output and fix any failures"
+
+# Broad rule with specific override (last match wins)
+after npm * "Check for any errors in the output"
+after npm install * ""
+
+# -----------------------------------------------------------------------------
 # SETTINGS
 # -----------------------------------------------------------------------------
 

--- a/editors/vscode/snippets.json
+++ b/editors/vscode/snippets.json
@@ -1,0 +1,60 @@
+{
+  "allow": {
+    "prefix": "allow",
+    "body": "allow ${1:pattern}",
+    "description": "Auto-approve matching commands"
+  },
+  "ask": {
+    "prefix": "ask",
+    "body": "ask ${1:pattern} \"${2:message}\"",
+    "description": "Prompt user for matching commands"
+  },
+  "deny": {
+    "prefix": "deny",
+    "body": "deny ${1:pattern} \"${2:message}\"",
+    "description": "Reject matching commands"
+  },
+  "allow-redirect": {
+    "prefix": ["allow-redirect", "allowr"],
+    "body": "allow-redirect ${1:/tmp/**}",
+    "description": "Allow output redirects to matching paths"
+  },
+  "ask-redirect": {
+    "prefix": ["ask-redirect", "askr"],
+    "body": "ask-redirect ${1:pattern} \"${2:message}\"",
+    "description": "Prompt for output redirects to matching paths"
+  },
+  "deny-redirect": {
+    "prefix": ["deny-redirect", "denyr"],
+    "body": "deny-redirect ${1:**/.env*} \"${2:message}\"",
+    "description": "Reject output redirects to matching paths"
+  },
+  "after": {
+    "prefix": "after",
+    "body": "after ${1:git commit *} \"${2:message}\"",
+    "description": "Post-action feedback to AI"
+  },
+  "set log": {
+    "prefix": ["set log", "log"],
+    "body": "set log ${1:~/.dippy/audit.log}",
+    "description": "Enable audit logging to path"
+  },
+  "set log-full": {
+    "prefix": ["set log-full", "logfull"],
+    "body": "set log-full",
+    "description": "Include full command in audit log"
+  },
+  "set default": {
+    "prefix": ["set default", "default"],
+    "body": "set default ${1|allow,ask|}",
+    "description": "Set default decision for unmatched commands"
+  },
+  "section": {
+    "prefix": ["section", "#"],
+    "body": [
+      "# ${1:Section}",
+      "$0"
+    ],
+    "description": "Comment section header"
+  }
+}

--- a/editors/vscode/syntaxes/dippy.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippy.tmLanguage.json
@@ -11,7 +11,7 @@
       "name": "comment.line.number-sign.dippy"
     },
     "rule": {
-      "begin": "^\\s*(allow-redirect|ask-redirect|deny-redirect|allow|ask|deny)\\b",
+      "begin": "^\\s*(allow-redirect|ask-redirect|deny-redirect|allow|ask|deny|after)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.dippy" }
       },

--- a/justfile
+++ b/justfile
@@ -35,3 +35,11 @@ lint *ARGS:
 # Format (--fix to apply changes)
 fmt *ARGS:
     uv run ruff format {{ if ARGS == "--fix" { "" } else { "--check" } }} 2>&1 | sed -u "s/^/[fmt] /" | tee /tmp/{{project}}-fmt.log
+
+# Install VS Code syntax highlighting extension
+vscode:
+    #!/usr/bin/env bash
+    cd editors/vscode
+    rm -f dippy-syntax-*.vsix
+    npx @vscode/vsce package
+    code --install-extension dippy-syntax-*.vsix


### PR DESCRIPTION
## Summary
- Document `after` rules (PostToolUse feedback) as a real feature instead of a proposal
- Add VS Code snippets for all keywords (`allow`, `ask`, `deny`, redirects, `after`, `set`)
- Simplify VS Code extension install with `just vscode`
- Bump extension version to 0.0.7