### PR TITLE
Respect --dangerously-skip-permissions mode

### DIFF
--- a/src/dippy/dippy.py
+++ b/src/dippy/dippy.py
@@ -285,6 +285,16 @@ def main():
 
             command = tool_input.get("command", "")
 
+        # Check for bypass permissions mode (Claude Code PreToolUse only)
+        # When --dangerously-skip-permissions is used, permission_mode is "bypassPermissions"
+        if hook_event != "PostToolUse":
+            permission_mode = input_data.get("permission_mode", "default")
+            if permission_mode in ("bypassPermissions", "dontAsk"):
+                logging.info(f"Bypass mode ({permission_mode}): {command}")
+                log_decision("allow", permission_mode, command=command)
+                print(json.dumps(approve(permission_mode)))
+                return
+
         # Route based on hook event type
         if hook_event == "PostToolUse":
             logging.info(f"PostToolUse: {command}")


### PR DESCRIPTION
Fixes #35

## Summary

- Detects when Claude Code is running with `--dangerously-skip-permissions` via the `permission_mode` field in hook input
- Auto-allows all commands when mode is `bypassPermissions` or `dontAsk`
- Maintains audit logging with the permission mode as the reason
- PostToolUse (after rules) still runs normally since those are informational, not permission checks