### PR TITLE
Add support for negation and arith-cmd constructs

### DIFF
--- a/src/dippy/core/analyzer.py
+++ b/src/dippy/core/analyzer.py
@@ -133,6 +133,14 @@ def _analyze_node(node, config: Config, cwd: Path) -> Decision:
         # time command - analyze the pipeline being timed
         return _analyze_node(node.pipeline, config, cwd)
 
+    elif kind == "negation":
+        # ! command - negates exit status, analyze the inner command
+        return _analyze_node(node.pipeline, config, cwd)
+
+    elif kind == "arith-cmd":
+        # (( expr )) - pure arithmetic, safe
+        return Decision("allow", "arithmetic")
+
     elif kind == "comment":
         return Decision("allow", "comment")
 

--- a/tests/test_analyzer_bugs.py
+++ b/tests/test_analyzer_bugs.py
@@ -73,3 +73,27 @@ class TestCmdsubInjectionWarning:
         result = analyze("kubectl $(echo delete) pod foo", config, cwd)
         assert result.action == "ask"
         assert "injection" in result.reason.lower()
+
+
+class TestNegationAndArith:
+    """Test negation (!) and arithmetic (( )) constructs."""
+
+    @pytest.fixture
+    def config(self):
+        return Config()
+
+    @pytest.fixture
+    def cwd(self):
+        return Path.cwd()
+
+    @pytest.mark.parametrize(
+        "cmd,expected",
+        [
+            ("! grep foo", "allow"),
+            ("! rm file", "ask"),
+            ("(( i++ ))", "allow"),
+            ("(( x = 5 ))", "allow"),
+        ],
+    )
+    def test_negation_and_arith(self, cmd, expected, config, cwd):
+        assert analyze(cmd, config, cwd).action == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1674,6 +1674,13 @@ class TestMcpEndToEnd:
         import json
         import sys
 
+        import dippy.core.config
+
+        # Isolate from user's ~/.dippy/config
+        monkeypatch.setattr(
+            dippy.core.config, "USER_CONFIG", tmp_path / "no-such-config"
+        )
+
         # Config with rule that won't match
         config_file = tmp_path / ".dippy"
         config_file.write_text("allow-mcp mcp__filesystem__*\n")


### PR DESCRIPTION
## Summary
- Handle `! command` (negation) by analyzing the inner pipeline
- Handle `(( expr ))` (arithmetic) as always safe
- Fix test isolation from user's `~/.dippy/config`