### PR TITLE
Check for command substitutions in arithmetic expressions

### DIFF
--- a/tests/test_analyzer_bugs.py
+++ b/tests/test_analyzer_bugs.py
@@ -93,6 +93,8 @@ class TestNegationAndArith:
             ("! rm file", "ask"),
             ("(( i++ ))", "allow"),
             ("(( x = 5 ))", "allow"),
+            ("(( x = $(echo 1) ))", "allow"),  # safe cmdsub
+            ("(( arr[$(rm -rf /)] ))", "ask"),  # dangerous cmdsub in subscript
         ],
     )
     def test_negation_and_arith(self, cmd, expected, config, cwd):


### PR DESCRIPTION
## Summary
- `(( expr ))` can contain `$(cmd)` which executes arbitrary commands
- Add `_find_cmdsubs_in_arith()` to recursively walk arithmetic AST
- Analyze any embedded command substitutions for safety