### PR TITLE
Add tee handler that respects redirect rules

### DIFF
--- a/src/dippy/cli/__init__.py
+++ b/src/dippy/cli/__init__.py
@@ -26,6 +26,9 @@ class Classification:
     action: Literal["approve", "ask", "delegate"]
     inner_command: str | None = None  # Required when action="delegate"
     description: str | None = None  # Optional, overrides default description
+    redirect_targets: tuple[str, ...] | None = (
+        None  # File targets to check against redirect rules
+    )
 
 
 class CLIHandler(Protocol):

--- a/src/dippy/cli/tee.py
+++ b/src/dippy/cli/tee.py
@@ -1,0 +1,35 @@
+"""tee command handler - writes stdin to files."""
+
+from dippy.cli import Classification
+
+COMMANDS = ["tee"]
+
+
+def classify(tokens: list[str]) -> Classification:
+    """Classify tee command by extracting target files."""
+    base = "tee"
+    targets = []
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t == "--":
+            # Everything after -- is a file
+            targets.extend(tokens[i + 1 :])
+            break
+        elif t.startswith("-"):
+            i += 1
+            continue
+        else:
+            targets.append(t)
+        i += 1
+    if not targets:
+        # tee with no files just copies stdin to stdout
+        return Classification("approve", description=base)
+    desc = (
+        f"{base} {targets[0]}" if len(targets) == 1 else f"{base} {len(targets)} files"
+    )
+    return Classification(
+        "approve",
+        description=desc,
+        redirect_targets=tuple(targets),
+    )

--- a/tests/cli/test_tee.py
+++ b/tests/cli/test_tee.py
@@ -1,0 +1,136 @@
+"""Tests for tee CLI handler."""
+
+from conftest import is_approved, needs_confirmation
+from dippy.core.config import Config, Rule
+
+
+class TestTeeBasic:
+    """Basic tee functionality tests without redirect rules."""
+
+    def test_tee_no_files(self, check):
+        """tee with no files just passes through - safe."""
+        result = check("tee")
+        assert is_approved(result)
+
+    def test_tee_only_flags(self, check):
+        """tee with only flags and no files - safe."""
+        result = check("tee -a")
+        assert is_approved(result)
+
+    def test_tee_help(self, check):
+        """tee --help should be approved."""
+        result = check("tee --help")
+        assert is_approved(result)
+
+    def test_tee_version(self, check):
+        """tee --version should be approved."""
+        result = check("tee --version")
+        assert is_approved(result)
+
+
+class TestTeeNeedsConfirmation:
+    """tee with files but no matching redirect rules needs confirmation."""
+
+    def test_tee_single_file(self, check):
+        """tee to a file without matching rule needs confirmation."""
+        result = check("tee /etc/passwd")
+        assert needs_confirmation(result)
+
+    def test_tee_multiple_files(self, check):
+        """tee to multiple files without matching rules needs confirmation."""
+        result = check("tee file1.txt file2.txt")
+        assert needs_confirmation(result)
+
+    def test_tee_with_append_flag(self, check):
+        """tee -a to file without matching rule needs confirmation."""
+        result = check("tee -a output.log")
+        assert needs_confirmation(result)
+
+
+class TestTeeWithRedirectRules:
+    """tee with redirect rules in config."""
+
+    def test_tee_allowed_by_rule(self, check, tmp_path):
+        """tee to path allowed by redirect rule should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee /tmp/out.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+    def test_tee_allowed_glob_pattern(self, check, tmp_path):
+        """tee to path matching glob pattern should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/**")])
+        result = check("tee /tmp/subdir/out.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+    def test_tee_with_append_allowed(self, check, tmp_path):
+        """tee -a to allowed path should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee -a /tmp/out.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+    def test_tee_multiple_files_all_allowed(self, check, tmp_path):
+        """tee to multiple files all matching rules should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee /tmp/a.txt /tmp/b.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+    def test_tee_multiple_files_one_not_allowed(self, check, tmp_path):
+        """tee to files where one doesn't match rule needs confirmation."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee /tmp/a.txt /etc/passwd", config=cfg, cwd=tmp_path)
+        assert needs_confirmation(result)
+
+    def test_tee_denied_by_rule(self, check, tmp_path):
+        """tee to path denied by redirect rule should be denied."""
+        cfg = Config(redirect_rules=[Rule("deny", "/etc/*")])
+        result = check("tee /etc/config", config=cfg, cwd=tmp_path)
+        output = result.get("hookSpecificOutput", {})
+        assert output.get("permissionDecision") == "deny"
+
+    def test_tee_ask_rule(self, check, tmp_path):
+        """tee to path with ask rule should ask."""
+        cfg = Config(redirect_rules=[Rule("ask", ".env*")])
+        result = check("tee .env.local", config=cfg, cwd=tmp_path)
+        assert needs_confirmation(result)
+
+
+class TestTeeInPipeline:
+    """tee used in pipelines."""
+
+    def test_pipeline_tee_no_files(self, check):
+        """echo | tee with no files - safe."""
+        result = check("echo hello | tee")
+        assert is_approved(result)
+
+    def test_pipeline_tee_needs_confirmation(self, check):
+        """echo | tee file without matching rule needs confirmation."""
+        result = check("echo hello | tee output.txt")
+        assert needs_confirmation(result)
+
+    def test_pipeline_tee_allowed(self, check, tmp_path):
+        """echo | tee to allowed path should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("echo hello | tee /tmp/out.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+
+class TestTeeEdgeCases:
+    """Edge cases for tee handler."""
+
+    def test_tee_double_dash(self, check, tmp_path):
+        """tee -- file treats everything after -- as files."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee -- /tmp/file.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+    def test_tee_long_flags(self, check, tmp_path):
+        """tee with long flags should be handled correctly."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee --append /tmp/out.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)
+
+    def test_tee_ignore_interrupts(self, check, tmp_path):
+        """tee -i (ignore interrupts) with allowed file should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check("tee -i /tmp/out.txt", config=cfg, cwd=tmp_path)
+        assert is_approved(result)


### PR DESCRIPTION
Closes #31

## Summary
- Add `redirect_targets` field to `Classification` dataclass for handlers to specify file targets
- Update analyzer to check handler-provided redirect targets against configured redirect rules
- Create `tee` handler that extracts target files and returns them as `redirect_targets`

This enables `tee /tmp/out.txt` to be auto-approved when an `allow-redirect /tmp/*` rule is configured.