### PR TITLE
Add MCP directive support to VS Code extension

### DIFF
--- a/editors/vscode/samples/exhaustive.dippy
+++ b/editors/vscode/samples/exhaustive.dippy
@@ -134,6 +134,28 @@ deny-redirect ~/.ssh/id_* "Never overwrite SSH keys"
 deny-redirect /etc/** "System config is off-limits"
 
 # -----------------------------------------------------------------------------
+# MCP TOOL RULES: allow-mcp, ask-mcp, deny-mcp, after-mcp
+# -----------------------------------------------------------------------------
+
+# Allow read-only GitHub operations
+allow-mcp mcp__github__get_*
+allow-mcp mcp__github__list_*
+allow-mcp mcp__github__search_*
+
+# Ask for write operations
+ask-mcp mcp__github__create_* "Creating GitHub resources"
+ask-mcp mcp__github__update_* "Modifying GitHub resources"
+
+# Deny destructive operations
+deny-mcp mcp__github__delete_* "No deletions without manual review"
+deny-mcp mcp__github__merge_* "Merges need manual approval"
+deny-mcp mcp__*__delete_* "Block all MCP delete operations"
+
+# After rules for MCP
+after-mcp mcp__github__create_* "Check the GitHub UI to verify"
+after-mcp mcp__github__create_pull_request * "Share the PR URL with the team"
+
+# -----------------------------------------------------------------------------
 # AFTER RULES: PostToolUse feedback
 # -----------------------------------------------------------------------------
 

--- a/editors/vscode/snippets.json
+++ b/editors/vscode/snippets.json
@@ -34,6 +34,26 @@
     "body": "after ${1:git commit *} \"${2:message}\"",
     "description": "Post-action feedback to AI"
   },
+  "allow-mcp": {
+    "prefix": ["allow-mcp", "allowm"],
+    "body": "allow-mcp ${1:mcp__github__get_*}",
+    "description": "Auto-approve matching MCP tools"
+  },
+  "ask-mcp": {
+    "prefix": ["ask-mcp", "askm"],
+    "body": "ask-mcp ${1:mcp__github__create_*} \"${2:message}\"",
+    "description": "Prompt user for matching MCP tools"
+  },
+  "deny-mcp": {
+    "prefix": ["deny-mcp", "denym"],
+    "body": "deny-mcp ${1:mcp__*__delete_*} \"${2:message}\"",
+    "description": "Reject matching MCP tools"
+  },
+  "after-mcp": {
+    "prefix": ["after-mcp", "afterm"],
+    "body": "after-mcp ${1:mcp__github__create_*} \"${2:message}\"",
+    "description": "Post-action feedback for MCP tools"
+  },
   "set log": {
     "prefix": ["set log", "log"],
     "body": "set log ${1:~/.dippy/audit.log}",

--- a/editors/vscode/syntaxes/dippy.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippy.tmLanguage.json
@@ -11,7 +11,7 @@
       "name": "comment.line.number-sign.dippy"
     },
     "rule": {
-      "begin": "^\\s*(allow-redirect|ask-redirect|deny-redirect|allow|ask|deny|after)\\b",
+      "begin": "^\\s*(allow-redirect|ask-redirect|deny-redirect|allow-mcp|ask-mcp|deny-mcp|after-mcp|allow|ask|deny|after)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.dippy" }
       },


### PR DESCRIPTION
## Summary
- Add syntax highlighting for `allow-mcp`, `ask-mcp`, `deny-mcp`, `after-mcp` directives
- Add snippets for MCP directives (with `allowm`/`askm`/`denym`/`afterm` shortcuts)
- Add MCP examples to exhaustive sample file