### PR TITLE
Fix CI running twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Just Check
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Limit `push` trigger to `main` branch only
- PRs now only run the `pull_request` check, not both `push` and `pull_request`