### PR TITLE
Prototype of WebSearch extension

### DIFF
--- a/src/dippy/dippy.py
+++ b/src/dippy/dippy.py
@@ -204,6 +204,16 @@ def check_command(command: str, config: Config, cwd: Path) -> dict:
         return ask(result.reason)
 
 
+def post_tool_response(message: str) -> dict:
+    """Return PostToolUse response with feedback for Claude."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": f"🐤 {message}",
+        }
+    }
+
+
 def handle_post_tool_use(command: str, config: Config, cwd: Path) -> None:
     """Handle PostToolUse hook - output feedback message if rule matches."""
     from dippy.core.config import match_after
@@ -212,7 +222,7 @@ def handle_post_tool_use(command: str, config: Config, cwd: Path) -> None:
     words = tokenize(command)
     message = match_after(words, config, cwd)
     if message:  # non-empty string
-        print(f"🐤 {message}")
+        print(json.dumps(post_tool_response(message)))
     # empty string or None = silent (no output)
 
 
@@ -251,7 +261,7 @@ def handle_mcp_post_tool_use(tool_name: str, config: Config) -> None:
     """Handle PostToolUse hook for MCP tools - output feedback if rule matches."""
     message = match_after_mcp(tool_name, config)
     if message:  # non-empty string
-        print(f"🐤 {message}")
+        print(json.dumps(post_tool_response(message)))
     # empty string or None = silent (no output)
 
 
@@ -285,7 +295,7 @@ def handle_web_post_tool_use(query: str, config: Config) -> None:
     """Handle PostToolUse hook for WebSearch - output feedback if rule matches."""
     message = match_after_web(query, config)
     if message:  # non-empty string
-        print(f"🐤 {message}")
+        print(json.dumps(post_tool_response(message)))
     # empty string or None = silent (no output)
 
 

--- a/src/dippy/dippy.py
+++ b/src/dippy/dippy.py
@@ -384,9 +384,10 @@ def main():
                     print(json.dumps(result))
                 return
 
-            # Check if this is a WebSearch tool
-            if tool_name == "WebSearch":
-                query = tool_input.get("query", "")
+            # Check if this is a web tool (Claude: WebSearch/WebFetch, Gemini: google_web_search/web_fetch)
+            if tool_name in ("WebSearch", "WebFetch", "google_web_search", "web_fetch"):
+                # WebSearch/google_web_search use query, WebFetch/web_fetch use url
+                match_value = tool_input.get("query") or tool_input.get("url", "")
                 # Check for bypass permissions mode first
                 if hook_event != "PostToolUse":
                     permission_mode = input_data.get("permission_mode", "default")
@@ -395,13 +396,13 @@ def main():
                         log_decision("allow", permission_mode)
                         print(json.dumps(approve(permission_mode)))
                         return
-                # Handle WebSearch tool
+                # Handle WebSearch/WebFetch tool
                 if hook_event == "PostToolUse":
-                    logging.info(f"PostToolUse WebSearch: {query}")
-                    handle_web_post_tool_use(query, config)
+                    logging.info(f"PostToolUse {tool_name}: {match_value}")
+                    handle_web_post_tool_use(match_value, config)
                 else:
-                    logging.info(f"Checking WebSearch: {query}")
-                    result = check_web_tool(query, config)
+                    logging.info(f"Checking {tool_name}: {match_value}")
+                    result = check_web_tool(match_value, config)
                     print(json.dumps(result))
                 return
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2295,16 +2295,12 @@ class TestMatchAfterWeb:
     """Test after-web rule matching for PostToolUse feedback."""
 
     def test_basic_match(self):
-        cfg = Config(
-            after_web_rules=[Rule("after", "*api*", message="Check version")]
-        )
+        cfg = Config(after_web_rules=[Rule("after", "*api*", message="Check version")])
         result = match_after_web("rest api tutorial", cfg)
         assert result == "Check version"
 
     def test_no_match(self):
-        cfg = Config(
-            after_web_rules=[Rule("after", "*api*", message="Check version")]
-        )
+        cfg = Config(after_web_rules=[Rule("after", "*api*", message="Check version")])
         result = match_after_web("python basics", cfg)
         assert result is None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,8 @@ from dippy.core.config import (
     match_command,
     match_mcp,
     match_redirect,
+    match_after_web,
+    match_web,
     parse_config,
 )
 
@@ -1925,3 +1927,403 @@ class TestAlias:
         m = match_command(c, cfg, tmp_path)
         assert m is not None
         assert m.decision == "allow"
+
+
+class TestParseConfigWebRules:
+    """Test parsing of WebSearch tool rules."""
+
+    def test_allow_web(self):
+        cfg = parse_config("allow-web")
+        assert len(cfg.web_rules) == 1
+        assert cfg.web_rules[0].decision == "allow"
+        assert cfg.web_rules[0].pattern == "*"
+
+    def test_allow_web_with_pattern(self):
+        cfg = parse_config("allow-web *framework*")
+        assert len(cfg.web_rules) == 1
+        assert cfg.web_rules[0].decision == "allow"
+        assert cfg.web_rules[0].pattern == "*framework*"
+
+    def test_ask_web_with_pattern_and_message(self):
+        cfg = parse_config('ask-web *password* "Sensitive search"')
+        assert len(cfg.web_rules) == 1
+        assert cfg.web_rules[0].decision == "ask"
+        assert cfg.web_rules[0].pattern == "*password*"
+        assert cfg.web_rules[0].message == "Sensitive search"
+
+    def test_ask_web_pattern_only(self):
+        cfg = parse_config("ask-web *secret*")
+        assert len(cfg.web_rules) == 1
+        assert cfg.web_rules[0].decision == "ask"
+        assert cfg.web_rules[0].pattern == "*secret*"
+        assert cfg.web_rules[0].message is None
+
+    def test_deny_web_with_pattern_and_message(self):
+        cfg = parse_config('deny-web *hack* "Blocked search"')
+        assert len(cfg.web_rules) == 1
+        assert cfg.web_rules[0].decision == "deny"
+        assert cfg.web_rules[0].pattern == "*hack*"
+        assert cfg.web_rules[0].message == "Blocked search"
+
+    def test_ask_web_no_pattern_skipped(self):
+        cfg = parse_config("ask-web")
+        assert cfg.web_rules == []
+
+    def test_deny_web_no_pattern_skipped(self):
+        cfg = parse_config("deny-web")
+        assert cfg.web_rules == []
+
+    def test_web_rules_mixed_with_other_rules(self):
+        cfg = parse_config("""
+allow git *
+allow-web
+deny rm -rf /*
+ask-web *password* "Review sensitive search"
+deny-web *malware* "Blocked"
+""")
+        assert len(cfg.rules) == 2
+        assert len(cfg.web_rules) == 3
+        assert cfg.web_rules[0].decision == "allow"
+        assert cfg.web_rules[0].pattern == "*"
+        assert cfg.web_rules[1].decision == "ask"
+        assert cfg.web_rules[1].pattern == "*password*"
+        assert cfg.web_rules[2].decision == "deny"
+        assert cfg.web_rules[2].pattern == "*malware*"
+
+
+class TestMergeConfigsWebRules:
+    """Test WebSearch rules merging."""
+
+    def test_web_rules_concatenate(self):
+        base = Config(web_rules=[Rule("allow", "*")])
+        overlay = Config(web_rules=[Rule("ask", "*password*")])
+        merged = _merge_configs(base, overlay)
+        assert len(merged.web_rules) == 2
+        assert merged.web_rules[0].pattern == "*"
+        assert merged.web_rules[1].pattern == "*password*"
+
+
+class TestTagRulesWeb:
+    """Test origin tagging for WebSearch rules."""
+
+    def test_tags_web_rules_with_source_and_scope(self):
+        config = Config(web_rules=[Rule("allow", "*")])
+        tagged = _tag_rules(config, "/path/to/config", SCOPE_USER)
+        assert tagged.web_rules[0].source == "/path/to/config"
+        assert tagged.web_rules[0].scope == SCOPE_USER
+
+
+class TestMatchWeb:
+    """Test WebSearch query matching against config rules."""
+
+    def test_allow_all_matches_any_query(self):
+        cfg = Config(web_rules=[Rule("allow", "*")])
+        m = match_web("python documentation 2026", cfg)
+        assert m is not None
+        assert m.decision == "allow"
+        assert m.pattern == "*"
+
+    def test_pattern_match(self):
+        cfg = Config(web_rules=[Rule("ask", "*password*", message="Sensitive")])
+        m = match_web("how to reset password", cfg)
+        assert m is not None
+        assert m.decision == "ask"
+        assert m.message == "Sensitive"
+
+    def test_no_match_returns_none(self):
+        cfg = Config(web_rules=[Rule("ask", "*password*")])
+        m = match_web("python docs", cfg)
+        assert m is None
+
+    def test_empty_rules_returns_none(self):
+        cfg = Config(web_rules=[])
+        m = match_web("any query", cfg)
+        assert m is None
+
+    def test_last_match_wins(self):
+        cfg = Config(
+            web_rules=[
+                Rule("allow", "*"),
+                Rule("ask", "*secret*", message="Review this"),
+            ]
+        )
+        # First rule matches but second is more specific and wins
+        m = match_web("company secret policy", cfg)
+        assert m is not None
+        assert m.decision == "ask"
+        assert m.message == "Review this"
+
+    def test_deny_with_message(self):
+        cfg = Config(web_rules=[Rule("deny", "*hack*", message="Blocked")])
+        m = match_web("hacking tutorials", cfg)
+        assert m is not None
+        assert m.decision == "deny"
+        assert m.message == "Blocked"
+
+    def test_match_object_fields(self):
+        cfg = Config(
+            web_rules=[
+                Rule(
+                    "ask",
+                    "*api*",
+                    message="API search",
+                    source="/path/to/config",
+                    scope="user",
+                )
+            ]
+        )
+        m = match_web("rest api tutorial", cfg)
+        assert m.decision == "ask"
+        assert m.pattern == "*api*"
+        assert m.message == "API search"
+        assert m.source == "/path/to/config"
+        assert m.scope == "user"
+
+    def test_complex_pattern_priority(self):
+        """Test that the most specific matching rule (last) wins."""
+        cfg = Config(
+            web_rules=[
+                Rule("allow", "*"),  # allow everything
+                Rule("ask", "*sensitive*"),  # ask for sensitive
+                Rule("deny", "*password*"),  # deny password searches
+            ]
+        )
+        # Normal query - should be allowed
+        m = match_web("python docs", cfg)
+        assert m.decision == "allow"
+        # Sensitive query - should ask
+        m = match_web("sensitive data handling", cfg)
+        assert m.decision == "ask"
+        # Password query - should be denied
+        m = match_web("how to store password", cfg)
+        assert m.decision == "deny"
+
+
+class TestWebEndToEnd:
+    """End-to-end tests simulating actual hook JSON input/output for WebSearch."""
+
+    def test_websearch_tool_routed_correctly(self, tmp_path, monkeypatch):
+        """Test that main() routes WebSearch tools through web rules."""
+        import io
+        import json
+        import sys
+
+        # Create config with web rule
+        config_file = tmp_path / ".dippy"
+        config_file.write_text("allow-web\n")
+
+        # Simulate Claude Code hook input for WebSearch tool
+        hook_input = {
+            "tool_name": "WebSearch",
+            "tool_input": {"query": "python documentation"},
+            "hook_event_name": "PreToolUse",
+        }
+
+        # Capture stdout and mock stdin
+        captured_output = io.StringIO()
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(hook_input)))
+        monkeypatch.setattr(sys, "stdout", captured_output)
+        monkeypatch.chdir(tmp_path)
+
+        # Reload and run
+        import importlib
+
+        import dippy.dippy
+
+        importlib.reload(dippy.dippy)
+        dippy.dippy.main()
+
+        # Verify output
+        output = json.loads(captured_output.getvalue())
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
+
+    def test_websearch_tool_no_match_defers(self, tmp_path, monkeypatch):
+        """Test that WebSearch tool with no matching rules returns empty (defer)."""
+        import io
+        import json
+        import sys
+
+        import dippy.core.config
+
+        # Isolate from user's ~/.dippy/config
+        monkeypatch.setattr(
+            dippy.core.config, "USER_CONFIG", tmp_path / "no-such-config"
+        )
+
+        # Config with rule that won't match (empty - no web rules)
+        config_file = tmp_path / ".dippy"
+        config_file.write_text("allow git *\n")
+
+        hook_input = {
+            "tool_name": "WebSearch",
+            "tool_input": {"query": "python docs"},
+            "hook_event_name": "PreToolUse",
+        }
+
+        captured_output = io.StringIO()
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(hook_input)))
+        monkeypatch.setattr(sys, "stdout", captured_output)
+        monkeypatch.chdir(tmp_path)
+
+        import importlib
+
+        import dippy.dippy
+
+        importlib.reload(dippy.dippy)
+        dippy.dippy.main()
+
+        output = json.loads(captured_output.getvalue())
+        assert output == {}  # Empty = defer to Claude's default
+
+    def test_websearch_tool_deny_blocks(self, tmp_path, monkeypatch):
+        """Test that deny-web rule actually blocks the search."""
+        import io
+        import json
+        import sys
+
+        config_file = tmp_path / ".dippy"
+        config_file.write_text('deny-web *hack* "Blocked search"\n')
+
+        hook_input = {
+            "tool_name": "WebSearch",
+            "tool_input": {"query": "hacking tutorials"},
+            "hook_event_name": "PreToolUse",
+        }
+
+        captured_output = io.StringIO()
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(hook_input)))
+        monkeypatch.setattr(sys, "stdout", captured_output)
+        monkeypatch.chdir(tmp_path)
+
+        import importlib
+
+        import dippy.dippy
+
+        importlib.reload(dippy.dippy)
+        dippy.dippy.main()
+
+        output = json.loads(captured_output.getvalue())
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+        assert (
+            "Blocked search" in output["hookSpecificOutput"]["permissionDecisionReason"]
+        )
+
+    def test_bash_tool_not_affected_by_web_rules(self, tmp_path, monkeypatch):
+        """Test that Bash commands still work and aren't affected by web rules."""
+        import io
+        import json
+        import sys
+
+        config_file = tmp_path / ".dippy"
+        config_file.write_text("deny-web *\n")  # Deny all web searches
+
+        # Bash tool, not WebSearch
+        hook_input = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "hook_event_name": "PreToolUse",
+        }
+
+        captured_output = io.StringIO()
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(hook_input)))
+        monkeypatch.setattr(sys, "stdout", captured_output)
+        monkeypatch.chdir(tmp_path)
+
+        import importlib
+
+        import dippy.dippy
+
+        importlib.reload(dippy.dippy)
+        dippy.dippy.main()
+
+        output = json.loads(captured_output.getvalue())
+        # ls is safe, should be approved (not affected by web deny rule)
+        assert output.get("hookSpecificOutput", {}).get("permissionDecision") == "allow"
+
+
+class TestParseConfigAfterWebRules:
+    """Test parsing of after-web rules for PostToolUse."""
+
+    def test_after_web_with_message(self):
+        cfg = parse_config('after-web *api* "Check API version compatibility"')
+        assert len(cfg.after_web_rules) == 1
+        assert cfg.after_web_rules[0].decision == "after"
+        assert cfg.after_web_rules[0].pattern == "*api*"
+        assert cfg.after_web_rules[0].message == "Check API version compatibility"
+
+    def test_after_web_pattern_only(self):
+        cfg = parse_config("after-web *docs*")
+        assert len(cfg.after_web_rules) == 1
+        assert cfg.after_web_rules[0].pattern == "*docs*"
+        assert cfg.after_web_rules[0].message is None
+
+    def test_after_web_no_pattern_skipped(self):
+        cfg = parse_config("after-web")
+        assert cfg.after_web_rules == []
+
+    def test_after_web_mixed_with_other_rules(self):
+        cfg = parse_config("""
+allow-web
+after-web *api* "Check version"
+deny-web *hack*
+""")
+        assert len(cfg.web_rules) == 2
+        assert len(cfg.after_web_rules) == 1
+
+
+class TestMergeConfigsAfterWebRules:
+    """Test after-web rules merging."""
+
+    def test_after_web_rules_concatenate(self):
+        base = Config(after_web_rules=[Rule("after", "*api*", message="msg1")])
+        overlay = Config(after_web_rules=[Rule("after", "*docs*", message="msg2")])
+        merged = _merge_configs(base, overlay)
+        assert len(merged.after_web_rules) == 2
+
+
+class TestTagRulesAfterWeb:
+    """Test origin tagging for after-web rules."""
+
+    def test_tags_after_web_rules_with_source_and_scope(self):
+        config = Config(after_web_rules=[Rule("after", "*api*")])
+        tagged = _tag_rules(config, "/path/to/config", SCOPE_USER)
+        assert tagged.after_web_rules[0].source == "/path/to/config"
+        assert tagged.after_web_rules[0].scope == SCOPE_USER
+
+
+class TestMatchAfterWeb:
+    """Test after-web rule matching for PostToolUse feedback."""
+
+    def test_basic_match(self):
+        cfg = Config(
+            after_web_rules=[Rule("after", "*api*", message="Check version")]
+        )
+        result = match_after_web("rest api tutorial", cfg)
+        assert result == "Check version"
+
+    def test_no_match(self):
+        cfg = Config(
+            after_web_rules=[Rule("after", "*api*", message="Check version")]
+        )
+        result = match_after_web("python basics", cfg)
+        assert result is None
+
+    def test_last_match_wins(self):
+        cfg = Config(
+            after_web_rules=[
+                Rule("after", "*", message="General feedback"),
+                Rule("after", "*api*", message="API-specific feedback"),
+            ]
+        )
+        result = match_after_web("rest api docs", cfg)
+        assert result == "API-specific feedback"
+
+    def test_pattern_only_is_silent(self):
+        cfg = Config(after_web_rules=[Rule("after", "*docs*")])
+        result = match_after_web("python docs", cfg)
+        assert result == ""
+
+    def test_empty_message_is_silent(self):
+        cfg = Config(after_web_rules=[Rule("after", "*docs*", message="")])
+        result = match_after_web("python docs", cfg)
+        assert result == ""


### PR DESCRIPTION
## Summary
- Add WebSearch tool rules support (`allow-web`, `ask-web`, `deny-web`, `after-web` directives)
- Pattern matching against search query strings using fnmatch globs
- Refactor PostToolUse hook output to use proper JSON structure with `hookSpecificOutput`

## Changes
- **config.py**: Add `web_rules` and `after_web_rules` to Config, parsing logic, and matching functions
- **dippy.py**: Route WebSearch tools through web rules, add `post_tool_response()` helper for structured JSON output
- **docs/config.md**: Document WebSearch rules syntax and usage
- **tests/test_config.py**: Comprehensive tests for parsing, matching, and end-to-end behavior