### PR TITLE
Add prefix matching for command patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Dippy is highly customizable. Beyond simple allow/deny rules, you can attach mes
 
 ```
 deny python "Use uv run python, which runs in project environment"
-deny rm -rf * "Use trash instead"
+deny rm -rf "Use trash instead"
 deny-redirect **/.env* "Never write secrets, ask me to do it"
 ```
 


### PR DESCRIPTION
## Summary

- Change pattern matching from exact-match to prefix-match by default
- Add `|` anchor for exact matching when needed
- Patterns with globs (`*`, `?`, `[`) unchanged

| Pattern | Matches |
|---------|---------|
| `allow git add` | `git add`, `git add .`, `git add -A` |
| `allow git add\|` | only `git add` |
| `allow git add *` | unchanged |

This is a breaking change: existing configs become more permissive. Users who need exact-match behavior should add `|` to their patterns.