### PR TITLE
Add alias keyword to VSCode syntax highlighting

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,2 @@
+samples/
+*.vsix

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Lily Dayton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,6 +3,11 @@
   "displayName": "Dippy Config Syntax",
   "description": "Syntax highlighting for Dippy config files",
   "version": "0.0.7",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ldayton/Dippy"
+  },
+  "license": "MIT",
   "engines": {
     "vscode": "^1.60.0"
   },

--- a/editors/vscode/syntaxes/dippy.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippy.tmLanguage.json
@@ -11,7 +11,7 @@
       "name": "comment.line.number-sign.dippy"
     },
     "rule": {
-      "begin": "^\\s*(allow-redirect|ask-redirect|deny-redirect|allow-mcp|ask-mcp|deny-mcp|after-mcp|allow|ask|deny|after)\\b",
+      "begin": "^\\s*(allow-redirect|ask-redirect|deny-redirect|allow-mcp|ask-mcp|deny-mcp|after-mcp|allow|ask|deny|after|alias)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.dippy" }
       },


### PR DESCRIPTION
## Summary
- Add `alias` keyword highlighting to match the new alias directive
- Add repository and license fields to package.json
- Add .vscodeignore to fix packaging warnings