### PR TITLE
Handle [ and test conditional commands as safe read-only operations

### DIFF
--- a/src/dippy/core/analyzer.py
+++ b/src/dippy/core/analyzer.py
@@ -286,6 +286,11 @@ def _analyze_command(node, config: Config, cwd: Path) -> Decision:
     if not words:
         return Decision("allow", "empty command")
 
+    # Conditional test commands ([ and test) - read-only, safe after cmdsub check
+    if base in ("[", "test"):
+        decisions.append(Decision("allow", "conditional test"))
+        return _combine(decisions)
+
     cmd_decision = _analyze_simple_command(words, config, cwd)
     decisions.append(cmd_decision)
 


### PR DESCRIPTION
## Summary

Fixes #61 - The confusing "🐤 [ -n" reason message when conditional tests appeared in nested constructs like while loops.

- Add handling for `[` and `test` commands in `_analyze_command` after cmdsubs/procsubs/redirects are analyzed
- Dangerous substitutions inside conditionals are still caught
- Simple conditional tests return `Decision("allow", "conditional test")`

## Tests

Added 19 tests in `TestConditionalTestCommands`:
- Basic `[` and `test` with exact reason assertions
- Conditionals nested in while loops
- The kinesis pipeline from the issue
- Dangerous cmdsubs (`rm`, `dd`) - correctly asks
- Safe cmdsubs (`ls`, `echo`, `pwd`) - correctly allows
- Edge cases: process substitutions, redirects, env var cmdsubs, param expansion cmdsubs