### PR TITLE
Add handler for script command

### DIFF
--- a/src/dippy/cli/script.py
+++ b/src/dippy/cli/script.py
@@ -1,0 +1,62 @@
+"""
+Script command handler for Dippy.
+
+The script command records terminal sessions or runs commands with a pseudo-TTY.
+When running a command, delegates to inner command check.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from dippy.cli import Classification
+
+COMMANDS = ["script"]
+
+# Flags that take an argument
+FLAGS_WITH_ARG = frozenset({"-t", "-T"})
+
+# Flags that don't take arguments
+FLAGS_NO_ARG = frozenset({"-a", "-d", "-e", "-F", "-k", "-p", "-q", "-r"})
+
+
+def classify(tokens: list[str]) -> Classification:
+    """Classify script command."""
+    if len(tokens) < 2:
+        return Classification("ask", description="script interactive")
+
+    # Parse tokens to find file and command
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--":
+            i += 1
+            break
+        if tok.startswith("-"):
+            if tok in FLAGS_WITH_ARG:
+                i += 2
+            elif tok in FLAGS_NO_ARG or (len(tok) > 1 and tok[1] != "-"):
+                i += 1
+            else:
+                i += 1
+        else:
+            break
+
+    if i >= len(tokens):
+        return Classification("ask", description="script interactive")
+
+    # tokens[i] is the file, tokens[i+1:] is the command (if any)
+    command_tokens = tokens[i + 1 :]
+
+    if not command_tokens:
+        # Check if it's playback mode (-p flag)
+        is_playback = any(
+            t == "-p" or (t.startswith("-") and "p" in t and not t.startswith("--"))
+            for t in tokens[1:i]
+        )
+        if is_playback:
+            return Classification("approve", description="script -p (playback)")
+        return Classification("ask", description="script interactive")
+
+    # Delegate to inner command - shlex.join handles quoting for re-parse
+    return Classification("delegate", inner_command=shlex.join(command_tokens))

--- a/tests/cli/test_script.py
+++ b/tests/cli/test_script.py
@@ -1,0 +1,78 @@
+"""Tests for script CLI handler."""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import is_approved, needs_confirmation
+from dippy.core.config import Config, Rule
+
+
+TESTS = [
+    # === SAFE: Command delegation with safe inner commands ===
+    ("script -q /dev/null ls", True),
+    ("script -q /dev/null pwd", True),
+    ("script -q /dev/null git status", True),
+    ("script -q /dev/null echo hello", True),
+    ("script /tmp/out.log ls -la", True),
+    ("script -a /tmp/out.log cat file.txt", True),
+    ("script -aq /dev/null ls", True),
+    ("script -q -a /dev/null ls", True),
+    #
+    # === SAFE: Playback mode (just reading a file) ===
+    ("script -p typescript", True),
+    ("script -dp typescript", True),
+    ("script -p -d typescript", True),
+    #
+    # === UNSAFE: Interactive sessions ===
+    ("script", False),
+    ("script typescript", False),
+    ("script -a typescript", False),
+    ("script -q /dev/null", False),
+    #
+    # === UNSAFE: Command delegation with unsafe inner commands ===
+    ("script -q /dev/null rm file.txt", False),
+    ("script -q /dev/null npm install", False),
+    ("script /tmp/out.log python script.py", False),
+    ("script -q /dev/null bash -c 'rm -rf /'", False),
+]
+
+
+@pytest.mark.parametrize("command,expected", TESTS)
+def test_command(check, command: str, expected: bool) -> None:
+    """Test that command safety is detected correctly."""
+    result = check(command)
+    if expected:
+        assert is_approved(result), f"Expected approved for: {command}"
+    else:
+        assert needs_confirmation(result), f"Expected confirmation for: {command}"
+
+
+class TestScriptConfigIntegration:
+    """Test that script respects user config rules."""
+
+    def test_config_allow_script_pattern_bypasses_handler(self, check):
+        """Config rule for script pattern approves before handler runs."""
+        config = Config(rules=[Rule("allow", "script -q /dev/null")])
+        # This would normally be blocked (rm is unsafe), but config takes priority
+        result = check("script -q /dev/null rm -rf /", config=config)
+        assert is_approved(result)
+
+    def test_config_deny_inner_command_blocks(self, check):
+        """Config deny rule on inner command blocks delegation."""
+        config = Config(rules=[Rule("deny", "rm", message="use trash")])
+        result = check("script -q /dev/null rm foo.txt", config=config)
+        assert not is_approved(result)
+
+    def test_config_allow_inner_command_approves(self, check):
+        """Config allow rule on inner command approves delegation."""
+        config = Config(rules=[Rule("allow", "python")])
+        # python script.py normally needs confirmation, but config allows it
+        result = check("script -q /dev/null python script.py", config=config)
+        assert is_approved(result)
+
+    def test_config_deny_script_blocks_all(self, check):
+        """Config deny rule on script blocks everything."""
+        config = Config(rules=[Rule("deny", "script", message="no recording")])
+        result = check("script -q /dev/null ls", config=config)
+        assert not is_approved(result)


### PR DESCRIPTION
## Summary

- Adds CLI handler for the `script` command (terminal session recorder)
- Delegates to inner command when running `script -q /dev/null <cmd>`
- Approves playback mode (`-p`) as read-only
- Blocks interactive sessions that record to files
- Includes config integration tests verifying rules are respected for both the outer command and delegated inner commands