### PR TITLE
Delegate fzf --bind execute/become to inner command check

### DIFF
--- a/src/dippy/cli/fzf.py
+++ b/src/dippy/cli/fzf.py
@@ -6,23 +6,60 @@ Most operations are safe (read-only filtering and display).
 
 Unsafe operations:
 - --listen-unsafe: Allows remote process execution via HTTP server
-- --bind with execute/execute-silent/become: Can run arbitrary commands
+- --bind with execute/execute-silent/become: Delegates to inner command check
 """
 
 from __future__ import annotations
+
+import re
 
 from dippy.cli import Classification
 
 COMMANDS = ["fzf"]
 
-# Unsafe bind actions that execute external commands
-UNSAFE_BIND_ACTIONS = frozenset(
+# Bind actions that execute external commands - delegate to inner command
+EXEC_BIND_ACTIONS = frozenset(
     {
         "execute",
         "execute-silent",
         "become",
     }
 )
+
+# Pattern to extract command from action(cmd) syntax
+PAREN_PATTERN = re.compile(r"(execute|execute-silent|become)\((.+)\)")
+
+# Pattern to extract command from action:cmd syntax
+COLON_PATTERN = re.compile(r"(execute|execute-silent|become):(\S+)")
+
+
+def _extract_exec_command(bind_value: str) -> str | None:
+    """Extract the command from execute/execute-silent/become actions."""
+    # Try parenthesis syntax: execute(cmd)
+    match = PAREN_PATTERN.search(bind_value)
+    if match:
+        return match.group(2)
+
+    # Try colon syntax: execute:cmd
+    match = COLON_PATTERN.search(bind_value)
+    if match:
+        return match.group(2)
+
+    return None
+
+
+def _has_exec_bind_action(bind_value: str) -> bool:
+    """Check if a bind value contains execute/execute-silent/become actions."""
+    for action in EXEC_BIND_ACTIONS:
+        if f"{action}(" in bind_value:
+            return True
+        if f"{action}:" in bind_value:
+            return True
+        parts = bind_value.replace(",", ":").replace("+", ":").split(":")
+        for part in parts:
+            if part == action:
+                return True
+    return False
 
 
 def classify(tokens: list[str]) -> Classification:
@@ -33,46 +70,27 @@ def classify(tokens: list[str]) -> Classification:
         if token == "--listen-unsafe" or token.startswith("--listen-unsafe="):
             return Classification("ask", description=f"{base} --listen-unsafe")
 
-        # Check for --bind with unsafe actions
+        # Check for --bind with exec actions
         if token == "--bind" or token.startswith("--bind="):
             # Get the bind value
             if token == "--bind":
-                # Value is in next token
                 if i + 1 < len(tokens):
                     bind_value = tokens[i + 1]
                 else:
                     continue
             else:
-                # Value is after =
                 bind_value = token[7:]  # len("--bind=") == 7
 
-            if _has_unsafe_bind_action(bind_value):
+            if _has_exec_bind_action(bind_value):
+                # Try to extract and delegate the inner command
+                inner_cmd = _extract_exec_command(bind_value)
+                if inner_cmd:
+                    return Classification(
+                        "delegate",
+                        inner_command=inner_cmd,
+                        description=f"{base} --bind",
+                    )
+                # Couldn't extract command, ask for confirmation
                 return Classification("ask", description=f"{base} --bind")
 
     return Classification("approve", description=base)
-
-
-def _has_unsafe_bind_action(bind_value: str) -> bool:
-    """Check if a bind value contains unsafe actions.
-
-    Bind format: KEY:ACTION or KEY:ACTION(ARGS) or KEY:ACTION:ARGS
-    Multiple bindings separated by commas.
-    """
-    # Look for unsafe action patterns in the bind value
-    # Actions can be: action(args), action:args, or just action
-    for action in UNSAFE_BIND_ACTIONS:
-        # Check for action( pattern (e.g., execute(vim {}))
-        if f"{action}(" in bind_value:
-            return True
-        # Check for action: pattern (e.g., execute:vim {})
-        if f"{action}:" in bind_value:
-            return True
-        # Check for action as standalone (e.g., in comma-separated list)
-        # This handles cases like "enter:execute" without args
-        # Split by common delimiters and check each part
-        parts = bind_value.replace(",", ":").replace("+", ":").split(":")
-        for part in parts:
-            if part == action:
-                return True
-
-    return False

--- a/tests/cli/test_fzf.py
+++ b/tests/cli/test_fzf.py
@@ -253,7 +253,7 @@ TESTS = [
     #
     ("fzf --height=50% --bind='enter:execute(vim {})'", False),
     ("fzf --multi --bind='ctrl-o:execute-silent(open {})'", False),
-    ("fzf --preview='cat {}' --bind='enter:become(less {})'", False),
+    ("fzf --preview='cat {}' --bind='enter:become(rm {})'", False),
     #
     # ==========================================================================
     # Edge cases


### PR DESCRIPTION
## Summary

- `fzf --bind='enter:execute(cat {})'` now delegates to inner command safety check
- Safe commands like `cat`, `less`, `echo` are approved
- Unsafe commands like `rm` still require confirmation
- Supports both `execute(cmd)` and `execute:cmd` syntaxes
- Also handles `execute-silent` and `become` actions