### PR TITLE
Add remote mode for docker/kubectl exec delegation

### DIFF
--- a/src/dippy/cli/__init__.py
+++ b/src/dippy/cli/__init__.py
@@ -31,6 +31,7 @@ class Classification:
     redirect_targets: tuple[str, ...] | None = (
         None  # File targets to check against redirect rules
     )
+    remote: bool = False  # Inner command runs in remote context (container, ssh, etc.)
 
 
 class CLIHandler(Protocol):

--- a/tests/test_dippy.py
+++ b/tests/test_dippy.py
@@ -1390,13 +1390,6 @@ TESTS = [
     ("docker wait mycontainer", False),
     ("docker container wait mycontainer", False),
     #
-    # docker - unsafe (exec runs arbitrary commands)
-    #
-    ("docker exec mycontainer ls", False),
-    ("docker exec -it mycontainer bash", False),
-    ("docker exec -u root mycontainer whoami", False),
-    ("docker container exec mycontainer ls", False),
-    #
     # docker - unsafe (image/container mutations)
     #
     ("docker create ubuntu", False),
@@ -3236,10 +3229,7 @@ TESTS = [
     ("kubectl scale deployment nginx --replicas=3", False),
     ("kubectl scale --replicas=5 -f deployment.yaml", False),
     ("kubectl autoscale deployment nginx --min=2 --max=10 --cpu-percent=80", False),
-    # kubectl - unsafe (exec/run/debug)
-    ("kubectl exec nginx -- ls /", False),
-    ("kubectl exec -it nginx -- bash", False),
-    ("kubectl exec -it nginx -c container -- sh", False),
+    # kubectl - unsafe (run/debug)
     ("kubectl run nginx --image=nginx", False),
     ("kubectl run nginx --image=nginx --restart=Never", False),
     ("kubectl run -it busybox --image=busybox -- sh", False),


### PR DESCRIPTION
## Summary

- `docker exec` and `kubectl exec` now delegate to inner command analysis with `remote=True`
- In remote mode, path-based checks are skipped since paths are container-local, not host-local
- Command-based rules still apply (e.g., `deny rm -rf` works in containers)

## Behavior

| Command | Result |
|---------|--------|
| `docker exec nginx cat /etc/passwd` | Approve (cat is safe) |
| `docker exec nginx rm -rf /` | Ask (rm is unsafe) |
| `kubectl exec pod -- ls /app` | Approve (ls is safe) |
| `kubectl exec pod -- sh -c 'rm -rf /'` | Ask (shell with rm) |

## What remote mode skips

- Redirect rules (paths are container-local)
- Path expansion (`./foo` doesn't expand to host cwd)
- `cd <literal>` path resolution
- Alias path resolution with path expansion

## For future handlers

Any handler can use `Classification("delegate", inner_command=..., remote=True)` to get these semantics automatically (e.g., for ssh).