### PR TITLE
Add shopt to SIMPLE_SAFE

### DIFF
--- a/src/dippy/core/allowlists.py
+++ b/src/dippy/core/allowlists.py
@@ -221,6 +221,7 @@ SIMPLE_SAFE = frozenset(
         # === Shell Builtins & Utilities ===
         "true",  # return success
         "false",  # return failure
+        "shopt",  # set/unset shell options (session-local)
         "sleep",  # delay for specified time
         "read",  # read line from stdin
         # === Terminal ===


### PR DESCRIPTION
## Summary

- Add `shopt` bash builtin to the SIMPLE_SAFE allowlist
- Shell options set via shopt only affect the current session and don't persist between invocations, making it safe regardless of arguments