### PR TITLE
Add handler for sample command

### DIFF
--- a/src/dippy/cli/sample.py
+++ b/src/dippy/cli/sample.py
@@ -1,0 +1,34 @@
+"""
+Sample command handler for Dippy.
+
+The sample command profiles a process and writes output to a file.
+By default it writes to /tmp which is safe; custom paths need approval.
+"""
+
+from __future__ import annotations
+
+from dippy.cli import Classification
+
+COMMANDS = ["sample"]
+
+
+def classify(tokens: list[str]) -> Classification:
+    """Classify sample command."""
+    if len(tokens) < 2:
+        return Classification("ask", description="sample (no target)")
+
+    # Look for -file flag
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "-file" and i + 1 < len(tokens):
+            filepath = tokens[i + 1]
+            # /tmp writes are safe (default behavior)
+            if filepath.startswith("/tmp/") or filepath.startswith("/tmp"):
+                return Classification("approve", description="sample -file /tmp/...")
+            # Custom paths need approval
+            return Classification("ask", description=f"sample -file {filepath}")
+        i += 1
+
+    # No -file flag means default /tmp output, which is safe
+    return Classification("approve", description="sample (default /tmp output)")

--- a/src/dippy/core/allowlists.py
+++ b/src/dippy/core/allowlists.py
@@ -171,7 +171,6 @@ SIMPLE_SAFE = frozenset(
         "pgrep",  # find processes by name
         "powermetrics",  # power and performance metrics
         "ps",  # list processes
-        "sample",  # profile a process
         "system_profiler",  # system hardware/software report
         "top",  # display process activity
         "vm_stat",  # virtual memory statistics

--- a/tests/cli/test_sample.py
+++ b/tests/cli/test_sample.py
@@ -1,0 +1,40 @@
+"""Test cases for sample."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import is_approved, needs_confirmation
+
+TESTS = [
+    # Safe operations (default /tmp output)
+    ("sample 1234", True),
+    ("sample Safari", True),
+    ("sample 1234 10", True),
+    ("sample 1234 10 1", True),
+    ("sample -wait Safari", True),
+    ("sample -mayDie 1234", True),
+    ("sample -fullPaths 1234", True),
+    ("sample -e 1234", True),
+    ("sample -wait -mayDie Safari 10", True),
+    # Safe: explicit /tmp path
+    ("sample -file /tmp/out.txt 1234", True),
+    ("sample -file /tmp/foo/bar.sample 1234", True),
+    ("sample 1234 -file /tmp/test.txt", True),
+    # Unsafe: custom file path
+    ("sample -file /home/user/out.txt 1234", False),
+    ("sample -file ./output.txt 1234", False),
+    ("sample -file ~/samples/out.txt 1234", False),
+    ("sample -file output.sample 1234", False),
+    ("sample 1234 -file /var/log/sample.txt", False),
+    # Edge case: no target
+    ("sample", False),
+]
+
+
+@pytest.mark.parametrize("command,expected", TESTS)
+def test_sample(check, command: str, expected: bool):
+    result = check(command)
+    if expected:
+        assert is_approved(result), f"Expected approve: {command}"
+    else:
+        assert needs_confirmation(result), f"Expected confirm: {command}"


### PR DESCRIPTION
## Summary

The `sample` command was incorrectly in SIMPLE_SAFE - it always writes output files:
- Default: writes to `/tmp/<app>_<date>_<time>.sample.txt`
- With `-file path`: writes to specified path

This PR moves `sample` to a handler that:
- Approves default usage (writes to /tmp)
- Approves explicit `-file /tmp/...` paths  
- Asks for custom `-file` paths

## Changes
- Remove `sample` from SIMPLE_SAFE
- Add `src/dippy/cli/sample.py` handler
- Add `tests/cli/test_sample.py` with 18 test cases