### PR TITLE
Add gzip/gunzip command handler

### DIFF
--- a/src/dippy/cli/gzip.py
+++ b/src/dippy/cli/gzip.py
@@ -1,0 +1,44 @@
+"""gzip/gunzip handler for Dippy.
+
+gzip compresses files, gunzip decompresses them.
+By default both modify files in-place (unsafe).
+Safe when using stdout, list, or test modes.
+"""
+
+from __future__ import annotations
+
+from dippy.cli import Classification, HandlerContext
+
+COMMANDS = ["gzip", "gunzip"]
+
+# Flags that make the command read-only/safe
+SAFE_FLAGS = frozenset(
+    {
+        "-c",
+        "--stdout",
+        "--to-stdout",  # output to stdout, keep original
+        "-l",
+        "--list",  # list compressed file contents
+        "-t",
+        "--test",  # test integrity
+        "--help",
+        "--version",
+    }
+)
+
+
+def classify(ctx: HandlerContext) -> Classification:
+    """Classify gzip/gunzip command."""
+    tokens = ctx.tokens
+    if not tokens:
+        return Classification("ask", description="gzip")
+    cmd = tokens[0]
+    for token in tokens[1:]:
+        # Handle combined short flags like -lv, -tv, -dc
+        if token.startswith("-") and not token.startswith("--"):
+            for char in token[1:]:
+                if f"-{char}" in SAFE_FLAGS:
+                    return Classification("allow", description=cmd)
+        if token in SAFE_FLAGS:
+            return Classification("allow", description=cmd)
+    return Classification("ask", description=cmd)

--- a/tests/cli/test_gzip.py
+++ b/tests/cli/test_gzip.py
@@ -1,0 +1,77 @@
+"""Test cases for gzip/gunzip commands."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import is_approved, needs_confirmation
+
+TESTS = [
+    # === SAFE: stdout mode (no file modification) ===
+    ("gunzip -c file.gz", True),
+    ("gunzip --stdout file.gz", True),
+    ("gzip -c file.txt", True),
+    ("gzip --stdout file.txt", True),
+    ("gunzip -c -f file.gz", True),  # -c makes it safe regardless of -f
+    #
+    # === SAFE: list mode (read-only) ===
+    ("gunzip -l file.gz", True),
+    ("gunzip --list file.gz", True),
+    ("gzip -l file.gz", True),
+    ("gzip --list file.gz", True),
+    ("gunzip -lv file.gz", True),  # verbose list
+    #
+    # === SAFE: test mode (read-only) ===
+    ("gunzip -t file.gz", True),
+    ("gunzip --test file.gz", True),
+    ("gzip -t file.gz", True),
+    ("gzip --test file.gz", True),
+    ("gunzip -tv file.gz", True),  # verbose test
+    #
+    # === SAFE: help and version ===
+    ("gunzip --help", True),
+    ("gunzip --version", True),
+    ("gzip --help", True),
+    ("gzip --version", True),
+    #
+    # === SAFE: decompress flag with safe flags ===
+    ("gzip -dc file.gz", True),  # decompress to stdout
+    ("gzip --decompress --stdout file.gz", True),
+    ("gzip -dt file.gz", True),  # decompress test
+    #
+    # === UNSAFE: default decompression (in-place, deletes .gz) ===
+    ("gunzip file.gz", False),
+    ("gunzip file1.gz file2.gz", False),
+    ("gunzip -f file.gz", False),  # force still modifies
+    ("gunzip --force file.gz", False),
+    ("gunzip -v file.gz", False),  # verbose still modifies
+    ("gunzip -k file.gz", False),  # keep original, but still writes
+    ("gunzip --keep file.gz", False),
+    #
+    # === UNSAFE: default compression (in-place, deletes original) ===
+    ("gzip file.txt", False),
+    ("gzip file1.txt file2.txt", False),
+    ("gzip -f file.txt", False),
+    ("gzip --force file.txt", False),
+    ("gzip -9 file.txt", False),  # compression level still modifies
+    ("gzip -k file.txt", False),  # keep but still writes
+    ("gzip --keep file.txt", False),
+    #
+    # === UNSAFE: decompress mode without stdout ===
+    ("gzip -d file.gz", False),
+    ("gzip --decompress file.gz", False),
+    #
+    # === UNSAFE: recursive operations ===
+    ("gunzip -r dir/", False),
+    ("gunzip --recursive dir/", False),
+    ("gzip -r dir/", False),
+    ("gzip --recursive dir/", False),
+]
+
+
+@pytest.mark.parametrize("command,expected", TESTS)
+def test_gzip(check, command: str, expected: bool):
+    result = check(command)
+    if expected:
+        assert is_approved(result), f"Expected approve: {command}"
+    else:
+        assert needs_confirmation(result), f"Expected confirm: {command}"


### PR DESCRIPTION
## Summary
- Add command handler for `gzip` and `gunzip` commands
- Classify commands as safe when using stdout (`-c`), list (`-l`), or test (`-t`) modes
- Require confirmation for all other operations since they modify or delete files in-place