### PR TITLE
Add iconv handler

### DIFF
--- a/src/dippy/cli/iconv.py
+++ b/src/dippy/cli/iconv.py
@@ -1,0 +1,45 @@
+"""iconv handler for Dippy."""
+
+from __future__ import annotations
+
+from dippy.cli import Classification, HandlerContext
+
+COMMANDS = ["iconv"]
+
+
+def classify(ctx: HandlerContext) -> Classification:
+    """Classify iconv command for safety.
+
+    iconv converts text encoding. Safe by default (writes to stdout),
+    but -o/--output writes to a file which needs redirect rule checking.
+    """
+    tokens = ctx.tokens
+
+    # Look for -o or --output flag
+    output_file = None
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t == "-o" or t == "--output":
+            if i + 1 < len(tokens):
+                output_file = tokens[i + 1]
+            i += 2
+            continue
+        if t.startswith("-o"):
+            output_file = t[2:]
+            i += 1
+            continue
+        if t.startswith("--output="):
+            output_file = t[9:]
+            i += 1
+            continue
+        i += 1
+
+    if output_file:
+        return Classification(
+            "allow",
+            description="iconv -o",
+            redirect_targets=(output_file,),
+        )
+
+    return Classification("allow", description="iconv")

--- a/tests/cli/test_iconv.py
+++ b/tests/cli/test_iconv.py
@@ -1,0 +1,67 @@
+"""Test cases for iconv."""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import is_approved, needs_confirmation
+from dippy.core.config import Config, Rule
+
+TESTS = [
+    # Safe operations (read-only, output to stdout)
+    ("iconv --help", True),
+    ("iconv --version", True),
+    ("iconv -l", True),
+    ("iconv --list", True),
+    ("iconv -f UTF-8 -t ASCII input.txt", True),
+    ("iconv --from-code=UTF-8 --to-code=ASCII input.txt", True),
+    ("iconv -f ISO-8859-1 -t UTF-8 file.txt", True),
+    ("iconv -c -f UTF-8 -t ASCII input.txt", True),  # omit invalid chars
+    ("iconv -s -f UTF-8 -t ASCII input.txt", True),  # silent mode
+    ("iconv --silent -f UTF-8 -t ASCII input.txt", True),
+    ("iconv --verbose -f UTF-8 -t ASCII input.txt", True),
+    # Unsafe operations (writes to file)
+    ("iconv -f UTF-8 -t ASCII -o output.txt input.txt", False),
+    ("iconv -f UTF-8 -t ASCII --output=output.txt input.txt", False),
+    ("iconv -f UTF-8 -t ASCII --output output.txt input.txt", False),
+    ("iconv -ooutput.txt -f UTF-8 -t ASCII input.txt", False),
+]
+
+
+@pytest.mark.parametrize("command,expected", TESTS)
+def test_command(check, command: str, expected: bool) -> None:
+    result = check(command)
+    if expected:
+        assert is_approved(result), f"Expected approve: {command}"
+    else:
+        assert needs_confirmation(result), f"Expected confirm: {command}"
+
+
+class TestIconvOutputWithRules:
+    """iconv -o should respect redirect rules."""
+
+    def test_iconv_output_allowed_by_rule(self, check, tmp_path):
+        """iconv -o to allowed path should be approved."""
+        cfg = Config(redirect_rules=[Rule("allow", "/tmp/*")])
+        result = check(
+            "iconv -f UTF-8 -t ASCII -o /tmp/output.txt input.txt",
+            config=cfg,
+            cwd=tmp_path,
+        )
+        assert is_approved(result)
+
+    def test_iconv_output_denied_by_rule(self, check, tmp_path):
+        """iconv -o to denied path should be denied."""
+        cfg = Config(redirect_rules=[Rule("deny", "/etc/*")])
+        result = check(
+            "iconv -f UTF-8 -t ASCII -o /etc/output.txt input.txt",
+            config=cfg,
+            cwd=tmp_path,
+        )
+        output = result.get("hookSpecificOutput", {})
+        assert output.get("permissionDecision") == "deny"
+
+    def test_iconv_output_to_dev_null(self, check):
+        """iconv -o to /dev/null should be approved."""
+        result = check("iconv -f UTF-8 -t ASCII -o /dev/null input.txt")
+        assert is_approved(result)


### PR DESCRIPTION
## Summary
- Add handler for `iconv` character encoding converter
- Safe by default (reads files, writes to stdout)
- `-o`/`--output` flag triggers redirect rule checking