### PR TITLE
Move logger setup to after MODE selection

### DIFF
--- a/src/dippy/dippy.py
+++ b/src/dippy/dippy.py
@@ -20,6 +20,7 @@ import os
 import sys
 from pathlib import Path
 
+from dippy.core.analyzer import analyze
 from dippy.core.config import (
     Config,
     ConfigError,
@@ -29,8 +30,6 @@ from dippy.core.config import (
     match_after_mcp,
     match_mcp,
 )
-from dippy.core.analyzer import analyze
-
 
 # === Mode Detection ===
 
@@ -86,17 +85,23 @@ def _get_log_file() -> Path:
     return Path.home() / ".claude" / "hook-approvals.log"
 
 
+_LOG_FORMAT = "%(asctime)s [%(levelname)s] %(message)s"
+_LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
 def setup_logging():
-    """Configure logging to file. Fails silently if unable to write."""
+    """Add a file handler for the detected mode's log directory.
+
+    Called after mode is finalized so the log file goes to the correct
+    directory (~/.claude/, ~/.cursor/, etc.). Fails silently.
+    """
     try:
         log_file = _get_log_file()
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        logging.basicConfig(
-            filename=str(log_file),
-            level=logging.INFO,
-            format="%(asctime)s [%(levelname)s] %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
+        handler = logging.FileHandler(str(log_file))
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
+        logging.getLogger().addHandler(handler)
     except (OSError, PermissionError):
         pass  # Logging is optional - don't crash if we can't write
 
@@ -304,7 +309,8 @@ def main():
         print("Run 'dippy --help' for usage.")
         raise SystemExit(0)
 
-    setup_logging()
+    # Stderr fallback so early errors (bad JSON, unknown tool) are visible
+    logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT, datefmt=_LOG_DATEFMT)
 
     try:
         # Read hook input from stdin
@@ -313,6 +319,11 @@ def main():
         # Auto-detect mode from input if no explicit flag/env was set
         if _EXPLICIT_MODE is None:
             MODE = _detect_mode_from_input(input_data)
+
+        # Add file handler now that mode (and thus log directory) is known
+        setup_logging()
+
+        if _EXPLICIT_MODE is None:
             logging.info(f"Auto-detected mode: {MODE}")
 
         # Extract cwd from input

--- a/src/dippy/dippy.py
+++ b/src/dippy/dippy.py
@@ -309,8 +309,16 @@ def main():
         print("Run 'dippy --help' for usage.")
         raise SystemExit(0)
 
-    # Stderr fallback so early errors (bad JSON, unknown tool) are visible
-    logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT, datefmt=_LOG_DATEFMT)
+    # Root passes INFO through to the file handler (added once the mode, and
+    # thus the log directory, is known). The stderr fallback only surfaces
+    # warnings/errors, so normal runs stay quiet there while early failures
+    # (bad JSON, unknown tool) are still visible before the file handler exists.
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    stderr_handler = logging.StreamHandler()
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
+    root.addHandler(stderr_handler)
 
     try:
         # Read hook input from stdin


### PR DESCRIPTION
Because we call `setup_logging` before deciding on the mode the log file is always `.claude/hook-approvals.log` even for cursor

This split the logger setup in two, first we do basic logging setup with the right format etc so that we don't lose messages related to parsing input and setup and then once we know the mode we are in we call the file logger.