### PR TITLE
Whitelist argparse and getopt as safe modules

### DIFF
--- a/src/dippy/cli/python.py
+++ b/src/dippy/cli/python.py
@@ -98,6 +98,11 @@ SAFE_MODULES = frozenset(
         "html",
         "html.parser",
         "html.entities",
+        # Argv parsing (pure string processing; sys.exit/--help to stdout is
+        # part of the CLI contract, not a security concern — print is already
+        # whitelisted, and termination is not in the threat model).
+        "argparse",
+        "getopt",
     }
 )
 
@@ -205,8 +210,6 @@ DANGEROUS_MODULES = frozenset(
         "cmd",
         "shlex",
         "getpass",
-        "getopt",
-        "argparse",  # Can sys.exit
         "logging",  # Can write to files
         "atexit",
         # CGI (Bandit B412: httpoxy vulnerabilities)

--- a/tests/cli/test_python.py
+++ b/tests/cli/test_python.py
@@ -125,6 +125,34 @@ print(json.dumps({"name": p.name, "age": p.age}))
         result = check(f"python {script}")
         assert is_approved(result), "Dataclass script should be approved"
 
+    def test_safe_script_argparse_approved(self, check, tmp_path):
+        """Script using argparse should be approved (pure argv parsing)."""
+        script = tmp_path / "argparse_script.py"
+        script.write_text("""
+import argparse
+
+parser = argparse.ArgumentParser(description="Demo")
+parser.add_argument("--count", type=int, default=1)
+parser.add_argument("name")
+args = parser.parse_args()
+print(f"Hello {args.name} x{args.count}")
+""")
+        result = check(f"python {script}")
+        assert is_approved(result), "argparse script should be approved"
+
+    def test_safe_script_getopt_approved(self, check, tmp_path):
+        """Script using getopt should be approved (pure argv parsing)."""
+        script = tmp_path / "getopt_script.py"
+        script.write_text("""
+import getopt
+
+opts, args = getopt.getopt(["--name", "Alice"], "", ["name="])
+for opt, val in opts:
+    print(opt, val)
+""")
+        result = check(f"python {script}")
+        assert is_approved(result), "getopt script should be approved"
+
     def test_dangerous_import_os_blocked(self, check, tmp_path):
         """Script importing os should be blocked."""
         script = tmp_path / "dangerous_os.py"


### PR DESCRIPTION
## Summary

Move `argparse` and `getopt` from `DANGEROUS_MODULES` to `SAFE_MODULES` in the Python handler. Both are pure argv-parsing stdlib modules whose only side effects are stdout/stderr text and `sys.exit` on bad args — none of which is in the analyser's threat model:

- `print` is already whitelisted, so `--help`/error text to stdout/stderr is consistent with existing policy.
- `sys.exit` just terminates the script — not code execution, file I/O, or network access.
- Neither module can read/write files, open sockets, spawn processes, or touch the filesystem.

## Motivation

Nearly every real-world CLI script imports `argparse`. Listing it as dangerous caused the static analyser to ask for approval on essentially every script the handler sees — defeating the handler's purpose of auto-approving provably safe code. I hit this constantly with my own CLI tooling under `scripts/`, which prompted a dig through `python.py`.

## What is deliberately NOT changed

- `logging` — real `FileHandler`/`SocketHandler`/`SMTPHandler` exist
- `sys` — `sys.modules` manipulation, `sys.stdin`/`sys.stdout` usable as file objects
- `getpass` — reads from tty (I/O)
- `atexit` — enables deferred execution of unreviewed handlers

These retain defensible I/O or exec vectors and stay in `DANGEROUS_MODULES`.

## Test plan

- [x] Added `test_safe_script_argparse_approved` and `test_safe_script_getopt_approved` in `TestPythonScriptAnalysis`, mirroring existing safe-import test style.
- [x] Full `tests/cli/test_python.py` suite (127 tests) passes on Python 3.14 via `uv run`.
- [x] Existing dangerous-import tests (`os`, `subprocess`, `pathlib`, `socket`, `requests`, etc.) unaffected.