### PR TITLE
Expand ~ in script paths before the existence check

### DIFF
--- a/src/dippy/cli/python.py
+++ b/src/dippy/cli/python.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from dippy.cli import Classification, HandlerContext
+from dippy.core.paths import resolve_arg_path
 
 COMMANDS = ["python", "python3"] + [f"python3.{v}" for v in range(8, 20)]
 
@@ -731,11 +732,7 @@ def _find_script_path(tokens: list[str], cwd: Path) -> tuple[Path | None, int]:
             continue
 
         # Found the script path
-        script_path = Path(token)
-        if not script_path.is_absolute():
-            script_path = cwd / script_path
-
-        return script_path.resolve(), i
+        return resolve_arg_path(token, cwd), i
 
     return None, -1
 

--- a/src/dippy/core/paths.py
+++ b/src/dippy/core/paths.py
@@ -1,0 +1,25 @@
+"""Path resolution for command-argument inspection.
+
+Resolves path-like command tokens to filesystem paths so handlers can
+inspect the referenced file (e.g. static-analyze a script before approving).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def resolve_arg_path(token: str, cwd: Path) -> Path:
+    """Resolve a command-line path token to a filesystem path for inspection.
+
+    Expands ``~``, ``~user``, and ``$VAR``/``${VAR}``, then anchors relative
+    paths to ``cwd``. Never raises: an unresolvable token (unknown user,
+    undefined variable) is left literal, so the resulting path simply won't
+    exist and the caller degrades to asking for confirmation.
+    """
+    expanded = os.path.expandvars(os.path.expanduser(token))
+    path = Path(expanded)
+    if not path.is_absolute():
+        path = cwd / path
+    return path.resolve()

--- a/src/dippy/core/paths.py
+++ b/src/dippy/core/paths.py
@@ -13,13 +13,16 @@ from pathlib import Path
 def resolve_arg_path(token: str, cwd: Path) -> Path:
     """Resolve a command-line path token to a filesystem path for inspection.
 
-    Expands ``~``, ``~user``, and ``$VAR``/``${VAR}``, then anchors relative
-    paths to ``cwd``. Never raises: an unresolvable token (unknown user,
-    undefined variable) is left literal, so the resulting path simply won't
-    exist and the caller degrades to asking for confirmation.
+    Expands ``~`` and ``~user``, then anchors relative paths to ``cwd`` —
+    matching the path normalization described in the security model. Variables
+    (``$HOME``) are intentionally left literal: the shell expands those after
+    approval, so we never guess their value from the hook's own environment.
+
+    Never raises: an unresolvable token (e.g. an unknown user) is left literal,
+    so the resulting path simply won't exist and the caller degrades to asking
+    for confirmation.
     """
-    expanded = os.path.expandvars(os.path.expanduser(token))
-    path = Path(expanded)
+    path = Path(os.path.expanduser(token))
     if not path.is_absolute():
         path = cwd / path
     return path.resolve()

--- a/tests/cli/test_python.py
+++ b/tests/cli/test_python.py
@@ -273,14 +273,6 @@ class TestPythonScriptPathExpansion:
         result = check("python3 ~/probe.py")
         assert is_approved(result), "tilde path should expand and be approved"
 
-    def test_env_var_path_not_expanded(self, check, tmp_path, monkeypatch):
-        """$VAR paths stay literal (security model): the shell expands them
-        after approval, so Dippy can't see the file and degrades to ask."""
-        monkeypatch.setenv("HOME", str(tmp_path))
-        (tmp_path / "probe.py").write_text(SAFE_SCRIPT)
-        result = check("python3 $HOME/probe.py")
-        assert needs_confirmation(result), "$HOME must not be expanded"
-
     def test_relative_path_anchored_to_cwd(self, check, tmp_path, monkeypatch):
         """A relative script path should resolve against the working directory."""
         (tmp_path / "probe.py").write_text(SAFE_SCRIPT)

--- a/tests/cli/test_python.py
+++ b/tests/cli/test_python.py
@@ -260,6 +260,39 @@ print("hello")
         assert needs_confirmation(result), "syntax error should be blocked"
 
 
+SAFE_SCRIPT = "import json\nprint(json.dumps({'ok': True}))\n"
+
+
+class TestPythonScriptPathExpansion:
+    """Tests for resolving script paths before analysis (issue #144)."""
+
+    def test_tilde_path_approved(self, check, tmp_path, monkeypatch):
+        """A safe script referenced via ~ should expand and be approved."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "probe.py").write_text(SAFE_SCRIPT)
+        result = check("python3 ~/probe.py")
+        assert is_approved(result), "tilde path should expand and be approved"
+
+    def test_home_var_path_approved(self, check, tmp_path, monkeypatch):
+        """A safe script referenced via $HOME should expand and be approved."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "probe.py").write_text(SAFE_SCRIPT)
+        result = check("python3 $HOME/probe.py")
+        assert is_approved(result), "$HOME path should expand and be approved"
+
+    def test_relative_path_anchored_to_cwd(self, check, tmp_path, monkeypatch):
+        """A relative script path should resolve against the working directory."""
+        (tmp_path / "probe.py").write_text(SAFE_SCRIPT)
+        monkeypatch.chdir(tmp_path)
+        result = check("python3 probe.py")
+        assert is_approved(result), "relative path should anchor to cwd"
+
+    def test_unknown_user_degrades_to_ask(self, check):
+        """An unknown ~user must not crash; it degrades to confirmation."""
+        result = check("python3 ~nosuchuser12345/probe.py")
+        assert needs_confirmation(result), "unknown ~user should degrade to ask"
+
+
 class TestPythonComplexScripts:
     """Tests for more complex Python scripts."""
 

--- a/tests/cli/test_python.py
+++ b/tests/cli/test_python.py
@@ -273,12 +273,13 @@ class TestPythonScriptPathExpansion:
         result = check("python3 ~/probe.py")
         assert is_approved(result), "tilde path should expand and be approved"
 
-    def test_home_var_path_approved(self, check, tmp_path, monkeypatch):
-        """A safe script referenced via $HOME should expand and be approved."""
+    def test_env_var_path_not_expanded(self, check, tmp_path, monkeypatch):
+        """$VAR paths stay literal (security model): the shell expands them
+        after approval, so Dippy can't see the file and degrades to ask."""
         monkeypatch.setenv("HOME", str(tmp_path))
         (tmp_path / "probe.py").write_text(SAFE_SCRIPT)
         result = check("python3 $HOME/probe.py")
-        assert is_approved(result), "$HOME path should expand and be approved"
+        assert needs_confirmation(result), "$HOME must not be expanded"
 
     def test_relative_path_anchored_to_cwd(self, check, tmp_path, monkeypatch):
         """A relative script path should resolve against the working directory."""

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -1,0 +1,47 @@
+"""
+Tests for the argument-path resolver.
+
+Covers the path normalization contract from the security model: ``~`` and
+relative paths are resolved, while variables are left literal (the shell
+expands those after approval).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dippy.core.paths import resolve_arg_path
+
+
+class TestResolveArgPath:
+    def test_tilde_expands_to_home(self, tmp_path, monkeypatch):
+        """~ resolves to the home directory (security model: ~/bar -> /home/user/bar)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = resolve_arg_path("~/script.py", cwd=Path("/some/other/dir"))
+        assert result == (tmp_path / "script.py").resolve()
+        assert "~" not in str(result)
+
+    def test_dollar_var_left_literal(self, tmp_path, monkeypatch):
+        """$VAR is NOT expanded: the shell expands it after approval, so the
+        resolver must not read it from the hook's own environment."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = resolve_arg_path("$HOME/script.py", cwd=tmp_path)
+        assert "$HOME" in str(result)
+        assert result != (tmp_path / "script.py").resolve()
+
+    def test_relative_anchored_to_cwd(self, tmp_path):
+        """Relative paths resolve against cwd."""
+        result = resolve_arg_path("sub/script.py", cwd=tmp_path)
+        assert result == (tmp_path / "sub" / "script.py").resolve()
+
+    def test_absolute_preserved(self, tmp_path):
+        """Absolute paths are not re-anchored to cwd."""
+        target = tmp_path / "script.py"
+        result = resolve_arg_path(str(target), cwd=Path("/some/other/dir"))
+        assert result == target.resolve()
+
+    def test_unknown_user_left_literal_without_raising(self, tmp_path):
+        """An unknown ~user must not raise; it stays literal so the path
+        simply won't exist and the caller can degrade to ask."""
+        result = resolve_arg_path("~nosuchuser12345/script.py", cwd=tmp_path)
+        assert "~nosuchuser12345" in str(result)


### PR DESCRIPTION
Fixes #144.

## Problem
The Python handler resolved a script path by joining the raw token onto the working directory. A `~`-prefixed path like `python3 ~/scripts/probe.py` became `<CWD>/~/scripts/probe.py` with a **literal** tilde — `pathlib` doesn't treat `~` as absolute, so it got anchored to cwd. The file was never found, and a safe, statically-analyzable script fell back to `ask`. This defeats Dippy's own preference for `python3 file.py` over `python3 -c "..."`: the file form is the one meant to get the fast path.

It also contradicted the documented security model, which already states path normalization expands `~/bar` → `/home/user/bar` before matching — the Python handler just wasn't doing it.

## Fix
New `core.paths.resolve_arg_path(token, cwd)` — a small, no-raise resolver that expands `~`/`~user`, then anchors relative paths to cwd. The Python handler routes through it instead of open-coding `cwd / Path(token)`.

Two deliberate design choices, both matching the security model:

- **`os.path.expanduser`, not `Path.expanduser()`.** `Path.expanduser()` raises `RuntimeError` on an unknown `~user` (verified on 3.7–3.14), which would turn a graceful `ask` into a crashed hook. The `os.path` function leaves unresolvable tokens literal, so they degrade to `ask`.
- **Variables (`$HOME`) are left literal.** The model keeps `$HOME` as `$HOME` and lets the shell expand it after approval, so the hook never guesses a variable's value from its own environment. The resolver only normalizes `~` and relative paths.

Placing this in `core/` makes it reusable for future handlers that grow script analysis (`script.py`, `uv.py`, ...) rather than re-introducing the same gap.

## Scope
Only the Python handler does script-file existence checks today; `shell.py` delegates to inner-command checking and never stats a path, so `bash ~/x.sh` doesn't hit this bug currently.

## Tests
- Unit (`tests/core/test_paths.py`): the resolver contract — `~` expands to home, relative anchors to cwd, absolute is preserved, `$VAR` is left literal (not read from the hook env), unknown `~user` stays literal without raising.
- Integration (`tests/cli/test_python.py`): tilde and relative script paths resolve and approve; unknown `~user` degrades to `ask` without crashing.

Full suite: 10,906 passing.