### PR TITLE
Guard find -fprint/-fprintf/-fls (they write to a file)

### DIFF
--- a/src/dippy/cli/find.py
+++ b/src/dippy/cli/find.py
@@ -14,6 +14,11 @@ from dippy.core.bash import bash_join
 
 COMMANDS = ["find"]
 
+# Actions that write find's output to a file (truncating it) — same effect as a
+# `> file` redirect, which Dippy already guards. The `f` prefix means "file"
+# (vs. -print/-printf/-ls which write to stdout and are safe).
+FILE_WRITE_ACTIONS = frozenset({"-fprint", "-fprint0", "-fprintf", "-fls"})
+
 # Context for flags that aren't self-explanatory
 FLAG_CONTEXT = {
     "-ok": "execute with prompt",
@@ -35,6 +40,10 @@ def classify(ctx: HandlerContext) -> Classification:
         # -delete always unsafe
         if token == "-delete":
             return Classification("ask", description=f"{base} -delete")
+
+        # -fprint/-fprintf/-fls write output to a file (truncating it)
+        if token in FILE_WRITE_ACTIONS:
+            return Classification("ask", description=f"{base} {token}")
 
         # -exec/-execdir - extract inner command and delegate
         if token in ("-exec", "-execdir"):

--- a/tests/cli/test_find.py
+++ b/tests/cli/test_find.py
@@ -138,10 +138,6 @@ TESTS = [
     ("find . -printf '%f\\n'", True),
     ("find . -printf '%p %s\\n'", True),
     ("find . -ls", True),
-    ("find . -fls /tmp/output.txt", True),
-    ("find . -fprint /tmp/output.txt", True),
-    ("find . -fprint0 /tmp/output.txt", True),
-    ("find . -fprintf /tmp/output.txt '%p\\n'", True),
     #
     # --- Boolean operators (safe) ---
     #
@@ -250,6 +246,14 @@ TESTS = [
     ("find . -name '*.bak' -type f -delete", False),
     ("find /tmp -name '*.cache' -delete", False),
     ("find . -mtime +30 -delete", False),
+    #
+    # --- -fprint/-fprintf/-fls (write output to a file, truncating it) ---
+    #
+    ("find . -fprint /tmp/output.txt", False),
+    ("find . -fprint0 /tmp/output.txt", False),
+    ("find . -fprintf /tmp/output.txt '%p\\n'", False),
+    ("find . -fls /tmp/output.txt", False),
+    ("find . -name '*.py' -fprint /etc/hosts", False),
     #
     # --- Combinations with safe exec ---
     #


### PR DESCRIPTION
Fixes #150.

`find`'s `-fprint`, `-fprint0`, `-fprintf`, and `-fls` write find's output to a file, **truncating it** — the same destructive effect as a `> file` redirect, which Dippy already guards. They'd been grouped with `-print`/`-printf`/`-ls` as safe "print actions", but those write to stdout; the `f` prefix means *file*.

This was an inconsistency: Dippy asks on one syntax and silently allows the other for the identical effect.

| Command | Before | After |
|---|---|---|
| `find . > /etc/hosts` | ask | ask |
| `find . -fprint /etc/hosts` | **allow** | **ask** |
| `find . -print` (stdout) | allow | allow |

## Changes
- `find.py`: route `-fprint`/`-fprint0`/`-fprintf`/`-fls` to `ask`, alongside `-delete`.
- `test_find.py`: move those four out of the "Print actions (safe)" cases (they were asserted approved) into the file-writing group, expecting `ask`.

Surfaced while investigating #130 (the `-delete` case, which was already guarded).

Full suite: 11001 passing.